### PR TITLE
Make containers.sh searchable + fix

### DIFF
--- a/containers.sh
+++ b/containers.sh
@@ -5,20 +5,26 @@ _base="$(dirname $_script)" ## Delete last component from $_script ##
 source neurodesk/configparser.sh ${_base}/config.ini
 
 install_all_containers="false"
-
-if [ "$1" != "" ]; then
+if [ "$1" = "--all" ]; then
+    echo "------------------------------------"
     echo "Installing all containers"
+    echo "------------------------------------"
+    echo
     install_all_containers="true"
+else
+    echo "------------------------------------"
+    echo "To install ALL containers, run:"
+    echo "bash containers.sh --all"
+    echo "------------------------------------"
+    echo "To install individual containers, run:"
+    echo
 fi
 
-echo "------------------------------------"
-echo "to install ALL containers, run:"
-echo "bash containers.sh --all"
-echo "------------------------------------"
-echo "to install individual containers, run:"
-echo
 while read appsh; do
       arrayIn=(${appsh//_/ })
+      if [[ -n "$1" ]] && [ "$install_all_containers" = "false" ] && ! [[ ${arrayIn[0]} == *"${1}"* ]]; then
+          continue
+      fi
       appcat=${arrayIn[@]:3}
       appcat_clean=${appcat:11:-1}                                                                                                                                                           
       apphead="| ${arrayIn[0]} | ${arrayIn[1]} | ${arrayIn[2]} | ${appcat_clean} | Run:"
@@ -58,9 +64,3 @@ while read appsh; do
         fi
     fi
 done < cvmfs/log.txt
-
-echo "------------------------------------"
-echo "to install ALL containers, run:"
-echo "bash containers.sh --all"
-echo "------------------------------------"
-echo "to install individual containers, run the above listed commands for each application"


### PR DESCRIPTION
Any input argument was always interpreted as `--al`. Now, if it's not `--all` then it is used as a matching pattern to only show the matching containers. Example:
```console
$ ./containers.sh diffusion
Reading config from /home/mrphys/marzwi/python/neurocommand/config.ini
------------------------------------
To install ALL containers, run:
bash containers.sh --all
------------------------------------
To install individual containers, run:

------------------------------------------------------------------
| diffusiontoolkit | 0.6.4.1 | 20220303 | diffusion imaging | Run:
------------------------------------------------------------------
./local/fetch_containers.sh diffusiontoolkit 0.6.4.1 20220303

-------------------------------------------------------------
| mitkdiffusion | 1.2.0 | 20230720 | diffusion imaging | Run:
-------------------------------------------------------------
./local/fetch_containers.sh mitkdiffusion 1.2.0 20230720
```