### PR TITLE
Added a help + the `--` option to install matching containers

### DIFF
--- a/.github/workflows/test_neurocommand.sh
+++ b/.github/workflows/test_neurocommand.sh
@@ -22,7 +22,7 @@ singularity --version
 echo "where am I"
 pwd
 bash build.sh --cli --lxde
-bash containers.sh
+bash containers.sh all
 bash /home/runner/work/neurocommand/neurocommand/local/fetch_containers.sh itksnap 3.8.0 20200811 itksnap /MRIcrop-orig.gipl
 
 

--- a/containers.sh
+++ b/containers.sh
@@ -14,7 +14,7 @@ if [[ -z "$1" ]] || [ "$1" = "-h" ] || [ "$1" = "--help" ] ; then
     echo "  $0 diffusion"
     echo "  $0 --bidscoin"
     echo
-    exit 1
+    exit 0
 fi
 
 _script="$(readlink -f ${BASH_SOURCE[0]})" ## who am i? ##

--- a/containers.sh
+++ b/containers.sh
@@ -14,7 +14,7 @@ if [[ -z "$1" ]] || [ "$1" = "-h" ] || [ "$1" = "--help" ] ; then
     echo "  $0 diffusion"
     echo "  $0 --bidscoin"
     echo
-    exit 0
+    exit 1
 fi
 
 _script="$(readlink -f ${BASH_SOURCE[0]})" ## who am i? ##


### PR DESCRIPTION
I couldn't help myself and implemented the option to install matching containers. The new behaviour:

```console
$ ./containers.sh               # Shows the help (NB: breaks old behaviour -- easily reverted if needed)
$ ./containers.sh -h            # Shows the help (new behaviour)
$ ./containers.sh --help        # Shows the help (new behaviour)
$ ./containers.sh all           # Shows all containers
$ ./containers.sh --all         # Installs all containers
$ ./containers.sh bidscoin      # Shows all 'bidscoin' containers
$ ./containers.sh --bidscoin    # Installs all 'bidscoin' containers (new behaviour)
```

This is a follow-up of PR #239 