### PR TITLE
Upgrade BIDScoin to v4.4.0

### DIFF
--- a/neurodesk/apps.json
+++ b/neurodesk/apps.json
@@ -158,6 +158,10 @@
             "bidscoin 4.3.3": {
                 "version": "20240716",
                 "exec": ""
+            },
+            "bidscoin 4.4.0": {
+                "version": "20241003",
+                "exec": ""
             }
         },
         "categories": ["data organisation"]


### PR DESCRIPTION
Previous times there an automatic(?) message suggesting to update the neurocommand app.json file. This time I didn't see it, but here's the updated json anyhow