### PR TITLE
Update apps.json

### DIFF
--- a/neurodesk/apps.json
+++ b/neurodesk/apps.json
@@ -414,8 +414,8 @@
                 "version": "20250207",
                 "exec": ""
             },
-            "deepretinotopy 1.0.9": {
-                "version": "20250328",
+            "deepretinotopy 1.0.10": {
+                "version": "20250409",
                 "exec": ""
             }
         },


### PR DESCRIPTION
updates for deepretinotopy to mask out the vertices without predictions with zeros