### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-neurocommand.yml
+++ b/.github/workflows/test-neurocommand.yml
@@ -1,4 +1,6 @@
 name: Test neurocommand
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurocommand/security/code-scanning/4](https://github.com/neurodesk/neurocommand/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs tests, it likely only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file, just below the `name:` field and before the `on:` block. This will apply the permission restriction to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
