### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -1,4 +1,6 @@
 name: generate-doi
+permissions:
+  contents: read
 
 on:
     schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurocommand/security/code-scanning/3](https://github.com/neurodesk/neurocommand/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow does not appear to need write access to repository contents, the safest minimal starting point is `contents: read`. This can be added at the top level of the workflow (applies to all jobs), or to individual jobs if different jobs require different permissions. In this case, adding it at the top level is simplest and most effective. Edit `.github/workflows/generate-doi.yml` to insert the following block after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
