### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-opening-issue.yml
+++ b/.github/workflows/on-opening-issue.yml
@@ -1,4 +1,5 @@
 name: on-opening-issue
+permissions: {}
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurocommand/security/code-scanning/2](https://github.com/neurodesk/neurocommand/security/code-scanning/2)

To fix the problem, add a `permissions` block at the top level of the workflow file (just after the `name:` or `on:` block). This block should specify the minimal permissions required for the workflow to function. Since the job only calls a reusable workflow and passes a personal access token via `secrets`, it is likely that no `GITHUB_TOKEN` permissions are needed, so the safest default is `permissions: {}` (no permissions). If the reusable workflow requires specific permissions, you can set them here (e.g., `issues: write`), but the minimal starting point is an empty object. The change should be made at the root of `.github/workflows/on-opening-issue.yml`, after the `name:` line and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
