### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-doi.yml
+++ b/.github/workflows/generate-doi.yml
@@ -1,4 +1,6 @@
 name: generate-doi
+permissions:
+  contents: read
 
 on:
     schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurocommand/security/code-scanning/1](https://github.com/neurodesk/neurocommand/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the `permissions` key at the root level of the workflow file, immediately after the `name` field and before the `on` field. This will apply the permissions to all jobs in the workflow unless overridden at the job level. Based on the workflow's actions (checking out code, running scripts, and publishing to Zenodo), the minimal required permission is likely `contents: read`. If the workflow needs to create issues or pull requests, those permissions can be added as needed, but from the provided code, only `contents: read` appears necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
