### PR TITLE
[codex] Regenerate OpenRefine webapp metadata

### DIFF
--- a/neurodesk/webapps.json
+++ b/neurodesk/webapps.json
@@ -40,6 +40,7 @@
     },
     "openrefine": {
       "title": "OpenRefine",
+      "icon": "https://raw.githubusercontent.com/NeuroDesk/neurocontainers/main/recipes/openrefine/icon.svg",
       "startup_command": "openrefine start",
       "startup_timeout": 180,
       "description": "Data cleaning and transformation tool",


### PR DESCRIPTION
## What changed

- Regenerated neurodesk/webapps.json from the updated Neurocontainers webapp metadata.
- Added the OpenRefine icon URL generated from recipes/openrefine/icon.svg.

## Dependency

Depends on https://github.com/neurodesk/neurocontainers/pull/2505 so the raw GitHub icon URL exists on neurocontainers/main.

## Why

OpenRefine previously had no icon field in neurocommand/neurodesk/webapps.json, so Neurodesktop fell back to /opt/neurodesk_brain_icon.svg for the webapp launcher tile.

## Validation

- python3 -m json.tool neurodesk/webapps.json
- Asserted webapps.openrefine.icon equals https://raw.githubusercontent.com/NeuroDesk/neurocontainers/main/recipes/openrefine/icon.svg
