### PR TITLE
Canonicalise apps.json ordering to match neurocontainers generator

### DIFF
--- a/.github/workflows/scripts/consolidate_appsjson_queue.py
+++ b/.github/workflows/scripts/consolidate_appsjson_queue.py
@@ -236,10 +236,29 @@ def changed_tools(before: Dict[str, Any], after: Dict[str, Any]) -> List[str]:
     return changed
 
 
+def sort_top_level_keys(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``payload`` with only its top-level (tool) keys sorted.
+
+    The neurocontainers release generator emits tools in alphabetical order but
+    preserves each tool's field order (e.g. ``version``/``exec``/``apptainer_args``
+    and ``apps``/``categories``). Sorting recursively (``sort_keys=True``) would
+    reorder those nested fields and reintroduce churn against the generator's
+    output, so we canonicalise only the top level. New tools added during
+    consolidation land as appended keys; sorting here puts them in their
+    alphabetical place so this repo's apps.json stays byte-compatible with the
+    generator and generator PRs show real changes only.
+    """
+    return {key: payload[key] for key in sorted(payload)}
+
+
 def write_json(path: str, payload: Dict[str, Any]) -> None:
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
+    # No trailing newline: the neurocontainers generator emits the file with a
+    # bare ``json.dump(..., indent=4)`` and gates its PRs on ``git diff --quiet``,
+    # so matching it byte-for-byte (top-level sorted, no final newline) is what
+    # keeps generator PRs free of reorder/newline-only churn.
+    out.write_text(json.dumps(sort_top_level_keys(payload), indent=4), encoding="utf-8")
 
 
 def render_appsjson_diff(
@@ -247,8 +266,11 @@ def render_appsjson_diff(
     base_payload: Dict[str, Any],
     consolidated_payload: Dict[str, Any],
 ) -> str:
-    base_text = json.dumps(base_payload, indent=4) + "\n"
-    consolidated_text = json.dumps(consolidated_payload, indent=4) + "\n"
+    # Match write_json's canonical form (top-level keys sorted, no trailing
+    # newline) so the diff shown in the PR body reflects what is actually
+    # committed to the consolidated branch.
+    base_text = json.dumps(sort_top_level_keys(base_payload), indent=4)
+    consolidated_text = json.dumps(sort_top_level_keys(consolidated_payload), indent=4)
     diff_lines = difflib.unified_diff(
         base_text.splitlines(),
         consolidated_text.splitlines(),

--- a/neurodesk/apps.json
+++ b/neurodesk/apps.json
@@ -397,6 +397,18 @@
             "data organisation"
         ]
     },
+    "blastct": {
+        "apps": {
+            "blastct 2.0.0": {
+                "version": "20260512",
+                "exec": "",
+                "apptainer_args": []
+            }
+        },
+        "categories": [
+            "structural imaging"
+        ]
+    },
     "blender": {
         "apps": {
             "blender 5.0.1": {
@@ -559,6 +571,18 @@
             "programming"
         ]
     },
+    "condaenvs": {
+        "apps": {
+            "condaenvs 1.0.1": {
+                "version": "20260513",
+                "exec": "",
+                "apptainer_args": []
+            }
+        },
+        "categories": [
+            "data organisation"
+        ]
+    },
     "conn": {
         "apps": {
             "connGUI-conn 20b": {
@@ -617,6 +641,18 @@
         },
         "categories": [
             "data organisation"
+        ]
+    },
+    "cosmomvpa": {
+        "apps": {
+            "cosmomvpa 1.1.0": {
+                "version": "20260512",
+                "exec": "",
+                "apptainer_args": []
+            }
+        },
+        "categories": [
+            "statistics"
         ]
     },
     "cpac": {
@@ -774,6 +810,18 @@
             "dsistudioGUI-dsistudio chen.2024.04.19": {
                 "version": "20240426",
                 "exec": "dsi_studio"
+            }
+        },
+        "categories": [
+            "diffusion imaging"
+        ]
+    },
+    "dwidenoise2": {
+        "apps": {
+            "dwidenoise2 20260603": {
+                "version": "20260604",
+                "exec": "",
+                "apptainer_args": []
             }
         },
         "categories": [
@@ -1322,6 +1370,10 @@
         "categories": [
             "image segmentation"
         ]
+    },
+    "irkernel": {
+        "apps": {},
+        "categories": []
     },
     "itksnap": {
         "apps": {
@@ -2199,6 +2251,19 @@
             "functional imaging"
         ]
     },
+    "prequal": {
+        "apps": {
+            "prequal 1.1.0": {
+                "version": "20260604",
+                "exec": "",
+                "apptainer_args": []
+            }
+        },
+        "categories": [
+            "diffusion imaging",
+            "quality control"
+        ]
+    },
     "pydeface": {
         "apps": {
             "pydeface 2.0.2": {
@@ -2904,71 +2969,6 @@
         },
         "categories": [
             "data organisation"
-        ]
-    },
-    "cosmomvpa": {
-        "apps": {
-            "cosmomvpa 1.1.0": {
-                "version": "20260512",
-                "exec": "",
-                "apptainer_args": []
-            }
-        },
-        "categories": [
-            "statistics"
-        ]
-    },
-    "irkernel": {
-        "apps": {},
-        "categories": []
-    },
-    "blastct": {
-        "apps": {
-            "blastct 2.0.0": {
-                "version": "20260512",
-                "exec": "",
-                "apptainer_args": []
-            }
-        },
-        "categories": [
-            "structural imaging"
-        ]
-    },
-    "condaenvs": {
-        "apps": {
-            "condaenvs 1.0.1": {
-                "version": "20260513",
-                "exec": "",
-                "apptainer_args": []
-            }
-        },
-        "categories": [
-            "data organisation"
-        ]
-    },
-    "prequal": {
-        "apps": {
-            "prequal 1.1.0": {
-                "version": "20260604",
-                "exec": "",
-                "apptainer_args": []
-            }
-        },
-        "categories": [
-            "diffusion imaging",
-            "quality control"
-        ]
-    },
-    "dwidenoise2": {
-        "apps": {
-            "dwidenoise2 20260603": {
-                "version": "20260604",
-                "exec": "",
-                "apptainer_args": []
-            }
-        },
-        "categories": [
-            "diffusion imaging"
         ]
     }
 }

--- a/test/test_consolidate_appsjson_canonical.py
+++ b/test/test_consolidate_appsjson_canonical.py
@@ -1,0 +1,93 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".github" / "workflows" / "scripts"
+SCRIPT = SCRIPTS / "consolidate_appsjson_queue.py"
+
+# The consolidation script imports sync_neurocontainer_icons from its own
+# directory, so make that importable before loading it.
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location("consolidate_appsjson_queue", SCRIPT)
+consolidate_appsjson_queue = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = consolidate_appsjson_queue
+spec.loader.exec_module(consolidate_appsjson_queue)
+
+
+def _sample_payload():
+    # Top-level keys deliberately out of order, with a tool appended last as the
+    # consolidation bot does for newly added tools. Nested fields use the
+    # generator's order (version, exec, apptainer_args -- NOT alphabetical).
+    return {
+        "blender": {
+            "apps": {"blender 5.0.1": {"version": "20260101", "exec": ""}},
+            "categories": ["image segmentation"],
+        },
+        "afni": {
+            "apps": {"afni 1.0": {"version": "20260101", "exec": "", "apptainer_args": []}},
+            "categories": ["functional imaging"],
+        },
+        # appended out of alphabetical order, as a freshly consolidated tool
+        "blastct": {
+            "apps": {"blastct 2.0.0": {"version": "20260512", "exec": "", "apptainer_args": []}},
+            "categories": ["structural imaging"],
+        },
+    }
+
+
+def test_sort_top_level_keys_sorts_only_top_level():
+    ordered = consolidate_appsjson_queue.sort_top_level_keys(_sample_payload())
+
+    # Top-level tool names alphabetised...
+    assert list(ordered) == ["afni", "blastct", "blender"]
+    # ...but nested field order is preserved (generator does not sort these).
+    assert list(ordered["afni"]["apps"]["afni 1.0"]) == ["version", "exec", "apptainer_args"]
+    assert list(ordered["blastct"]) == ["apps", "categories"]
+
+
+def test_write_json_matches_generator_byte_form(tmp_path):
+    out = tmp_path / "apps.json"
+    payload = _sample_payload()
+    consolidate_appsjson_queue.write_json(str(out), payload)
+
+    text = out.read_text()
+    # Byte-identical to the neurocontainers generator's serialization: top-level
+    # sorted, indent=4, default separators, NO trailing newline.
+    expected = json.dumps({k: payload[k] for k in sorted(payload)}, indent=4)
+    assert text == expected
+    assert not text.endswith("\n")
+
+
+def test_write_json_is_idempotent(tmp_path):
+    out = tmp_path / "apps.json"
+    consolidate_appsjson_queue.write_json(str(out), _sample_payload())
+    first = out.read_text()
+    # Re-writing the already-canonical payload must not change a single byte.
+    consolidate_appsjson_queue.write_json(str(out), json.loads(first))
+    assert out.read_text() == first
+
+
+def test_render_diff_ignores_pure_reordering():
+    base = _sample_payload()
+    # Same content, different top-level insertion order -> canonicalisation must
+    # collapse it to an empty diff (no phantom reorder churn in the PR body).
+    reordered = {k: base[k] for k in reversed(list(base))}
+    diff = consolidate_appsjson_queue.render_appsjson_diff("neurodesk/apps.json", base, reordered)
+    assert diff == ""
+
+
+def test_render_diff_shows_real_change_only():
+    base = _sample_payload()
+    changed = json.loads(json.dumps(base))
+    changed["afni"]["apps"]["afni 1.0"]["version"] = "20260601"
+    diff = consolidate_appsjson_queue.render_appsjson_diff("neurodesk/apps.json", base, changed)
+
+    added = [line for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++")]
+    removed = [line for line in diff.splitlines() if line.startswith("-") and not line.startswith("---")]
+    assert any('"version": "20260601"' in line for line in added)
+    assert any('"version": "20260101"' in line for line in removed)
+    # Only the single version line changed on each side.
+    assert len(added) == 1 and len(removed) == 1


### PR DESCRIPTION
## Problem

`neurodesk/apps.json` is written by two automations that disagreed on canonical form:

- The **neurocontainers release generator** (opens "Update apps.json from neurocontainers releases" PRs) regenerates the whole file with **top-level tool keys sorted alphabetically** and **no trailing newline**, preserving nested field order.
- This repo's **consolidation bot** (`consolidate_appsjson_queue.py`) appended newly-added tools at the **end** (dict insertion order) and emitted a **trailing newline**.

Result: new tools piled up out of order at the bottom of `main`, so every generator PR showed a large reorder + newline-only diff that buried the one real change. In [#675](https://github.com/neurodesk/neurocommand/pull/675) a 68+/68− diff contained only ~2 lines of real change (a functionnectome version bump); the rest was phantom churn.

## Fix

- Add `sort_top_level_keys()` and apply it in `write_json()` and `render_appsjson_diff()`.
- Sort **only the top level** — `sort_keys=True` would recursively reorder nested fields (`version`/`exec`/`apptainer_args`) and reintroduce churn.
- Drop the trailing newline so output is **byte-identical** to the generator (`json.dumps(indent=4)`), whose workflow gates on `git diff --quiet`.
- One-time re-sort of `neurodesk/apps.json` into that canonical form — a **pure reorder**, no content change (verified `dict ==`, identical key set, 165 keys, nested order preserved).

## Tests

- New `test/test_consolidate_appsjson_canonical.py`: top-level sort, nested-order preservation, generator byte-parity, idempotency, and reorder-only diffs collapsing to empty.
- Full consolidator suite: **8 passed**.

## Net effect

Both automations now produce identical canonical output, so future generator PRs show **real changes only**.

Reviewed by Codex, which confirmed the generator does not sort nested keys and caught the trailing-newline mismatch (now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)