### PR TITLE
Support named container variants end to end

### DIFF
--- a/.github/workflows/cleanup_neurocontainers.yml
+++ b/.github/workflows/cleanup_neurocontainers.yml
@@ -21,6 +21,13 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - name: Check out neurocontainers release metadata
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        repository: neurodesk/neurocontainers
+        path: neurocontainers-release-metadata
+        sparse-checkout: releases
+        sparse-checkout-cone-mode: true
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.8
@@ -67,5 +74,6 @@ jobs:
 
         python3 .github/workflows/scripts/cleanup_stale_containers.py \
           --s3-bucket "neurocontainers" \
+          --releases-dir "neurocontainers-release-metadata/releases" \
           --retention-days 7 \
           --apply

--- a/.github/workflows/cleanup_neurocontainers.yml
+++ b/.github/workflows/cleanup_neurocontainers.yml
@@ -21,6 +21,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
     - name: Check out neurocontainers release metadata
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
@@ -28,6 +30,7 @@ jobs:
         path: neurocontainers-release-metadata
         sparse-checkout: releases
         sparse-checkout-cone-mode: true
+        persist-credentials: false
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: 3.8

--- a/.github/workflows/scripts/cleanup_stale_containers.py
+++ b/.github/workflows/scripts/cleanup_stale_containers.py
@@ -96,6 +96,29 @@ def load_expected_keys(log_path: Path) -> Set[str]:
     return expected_keys
 
 
+def load_release_keys(releases_dir: Path) -> Set[str]:
+    """Return image keys referenced by neurocontainers release metadata."""
+    expected_keys: Set[str] = set()
+    if not releases_dir.is_dir():
+        raise SystemExit(f"[ERROR] Releases directory not found: {releases_dir}")
+
+    for release_path in releases_dir.glob("*/*.json"):
+        try:
+            release = json.loads(release_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"[ERROR] Could not read release metadata {release_path}: {exc}")
+
+        apps = release.get("apps", {})
+        for app in apps.values():
+            builddate = app.get("version")
+            if not isinstance(builddate, str) or not re.fullmatch(r"[0-9]{8}", builddate):
+                continue
+            image = app.get("image") or f"{release_path.parent.name}_{release_path.stem}"
+            expected_keys.add(f"{image}_{builddate}.simg")
+
+    return expected_keys
+
+
 def list_nectar_objects(remote_root: str) -> List[dict]:
     try:
         lsjson = subprocess.check_output(
@@ -256,6 +279,10 @@ def main() -> None:
     parser.add_argument("--s3-bucket", required=True, help="S3 bucket name")
     parser.add_argument("--remote-root", default="nectar:/neurodesk/", help="Nectar remote path")
     parser.add_argument("--log-path", default="log.txt", help="Path to log file")
+    parser.add_argument(
+        "--releases-dir",
+        help="Path to neurocontainers release metadata; referenced images are protected",
+    )
     parser.add_argument("--retention-days", type=int, default=30, help="Retention period in days")
     parser.add_argument(
         "--skip-log-generation",
@@ -283,6 +310,10 @@ def main() -> None:
         generate_log(log_path)
         normalize_log(log_path)
     expected_keys = load_expected_keys(log_path)
+    if args.releases_dir:
+        release_keys = load_release_keys(Path(args.releases_dir))
+        expected_keys.update(release_keys)
+        print(f"[DEBUG] Protected container count from release metadata: {len(release_keys)}")
 
     print(f"[DEBUG] Expected container count from log: {len(expected_keys)}")
     print(f"[DEBUG] Retention window for stale deletions: {args.retention_days} day(s)")

--- a/.github/workflows/scripts/cleanup_stale_containers.py
+++ b/.github/workflows/scripts/cleanup_stale_containers.py
@@ -102,18 +102,44 @@ def load_release_keys(releases_dir: Path) -> Set[str]:
     if not releases_dir.is_dir():
         raise SystemExit(f"[ERROR] Releases directory not found: {releases_dir}")
 
-    for release_path in releases_dir.glob("*/*.json"):
+    for release_path in sorted(releases_dir.glob("*/*.json")):
         try:
             release = json.loads(release_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise SystemExit(f"[ERROR] Could not read release metadata {release_path}: {exc}")
 
-        apps = release.get("apps", {})
-        for app in apps.values():
+        if not isinstance(release, dict):
+            raise SystemExit(f"[ERROR] Invalid release metadata {release_path}: expected an object")
+
+        apps = release.get("apps")
+        if not isinstance(apps, dict) or not apps:
+            raise SystemExit(
+                f"[ERROR] Invalid release metadata {release_path}: "
+                "'apps' must be a non-empty object"
+            )
+
+        for app_name, app in apps.items():
+            if not isinstance(app, dict):
+                raise SystemExit(
+                    f"[ERROR] Invalid release metadata {release_path}: "
+                    f"app {app_name!r} must be an object"
+                )
             builddate = app.get("version")
             if not isinstance(builddate, str) or not re.fullmatch(r"[0-9]{8}", builddate):
-                continue
-            image = app.get("image") or f"{release_path.parent.name}_{release_path.stem}"
+                raise SystemExit(
+                    f"[ERROR] Invalid release metadata {release_path}: "
+                    f"app {app_name!r} has invalid build date {builddate!r}"
+                )
+
+            if "image" in app:
+                image = app["image"]
+                if not isinstance(image, str) or not image:
+                    raise SystemExit(
+                        f"[ERROR] Invalid release metadata {release_path}: "
+                        f"app {app_name!r} has invalid image {image!r}"
+                    )
+            else:
+                image = f"{release_path.parent.name}_{release_path.stem}"
             expected_keys.add(f"{image}_{builddate}.simg")
 
     return expected_keys

--- a/cvmfs/reconcile_module_files.py
+++ b/cvmfs/reconcile_module_files.py
@@ -48,7 +48,7 @@ def parse_image_name(image: str) -> tuple[str, str, str]:
         name_and_version, builddate = stem.rsplit("_", 1)
         tool, version = name_and_version.rsplit("_", 1)
     except ValueError:
-        raise ValueError(f"invalid container image name in log.txt: {image}")
+        raise ValueError(f"invalid container image name in log.txt: {image}") from None
     if not tool or not version or not re.fullmatch(r"[0-9]{8}", builddate):
         raise ValueError(f"invalid container image name in log.txt: {image}")
     return tool, version, builddate

--- a/cvmfs/reconcile_module_files.py
+++ b/cvmfs/reconcile_module_files.py
@@ -43,10 +43,15 @@ class PlannedChange:
 
 
 def parse_image_name(image: str) -> tuple[str, str, str]:
-    parts = image.split("_")
-    if len(parts) < 3:
+    stem = image.removesuffix(".simg")
+    try:
+        name_and_version, builddate = stem.rsplit("_", 1)
+        tool, version = name_and_version.rsplit("_", 1)
+    except ValueError:
         raise ValueError(f"invalid container image name in log.txt: {image}")
-    return parts[0], parts[1], parts[2]
+    if not tool or not version or not re.fullmatch(r"[0-9]{8}", builddate):
+        raise ValueError(f"invalid container image name in log.txt: {image}")
+    return tool, version, builddate
 
 
 def normalize_category(category: str) -> str:

--- a/cvmfs/sync_containers_to_cvmfs.sh
+++ b/cvmfs/sync_containers_to_cvmfs.sh
@@ -346,59 +346,51 @@ do
 
 
         
-        # check if singularity image is already in object storage
-        if curl --output /dev/null --silent --head --fail "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/${IMAGENAME_BUILDDATE}.simg"; then
-            echo "[DEBUG] ${IMAGENAME_BUILDDATE}.simg exists in nectar cloud"
-            # in case of problems:
-            # cvmfs_server check
-            # If you get bad whitelist error, check if the repository is signed: sudo /usr/bin/cvmfs_server resign neurodesk.ardc.edu.au
-            open_cvmfs_transaction neurodesk.ardc.edu.au
+        # Let transparent-singularity try every supported backend. A Nectar-only
+        # preflight would skip images that are available from S3 or a registry.
+        open_cvmfs_transaction neurodesk.ardc.edu.au
 
-            cd /cvmfs/neurodesk.ardc.edu.au/containers/
+        cd /cvmfs/neurodesk.ardc.edu.au/containers/
 
-            # A leftover directory from a previous failed run would make git clone
-            # fail and silently reuse a stale transparent-singularity checkout.
-            # The outer commands.txt check already skipped completed installs, so
-            # anything here is an incomplete install and safe to remove.
-            if [[ -e "$IMAGENAME_BUILDDATE" ]]; then
-                echo "[WARNING] Removing stale leftover directory from a previous failed run: $IMAGENAME_BUILDDATE"
-                sudo rm -rf "$IMAGENAME_BUILDDATE"
-            fi
+        # The outer commands.txt check already skipped completed installs, so
+        # anything here is an incomplete install and safe to remove.
+        if [[ -e "$IMAGENAME_BUILDDATE" ]]; then
+            echo "[WARNING] Removing stale leftover directory from a previous failed run: $IMAGENAME_BUILDDATE"
+            sudo rm -rf "$IMAGENAME_BUILDDATE"
+        fi
 
-            if ! git clone https://github.com/NeuroDesk/transparent-singularity "$IMAGENAME_BUILDDATE"; then
-                echo "[ERROR] Failed to clone transparent-singularity for $IMAGENAME_BUILDDATE. Aborting transaction."
-                abort_cvmfs_transaction neurodesk.ardc.edu.au
-                continue
-            fi
+        # Use the scripts from this exact neurocommand checkout. Cloning the
+        # separate transparent-singularity repository bypasses fixes tested here.
+        if ! mkdir -p "$IMAGENAME_BUILDDATE" || \
+           ! cp -a "$NEUROCOMMAND_LOCAL_REPO/neurodesk/transparent-singularity/." "$IMAGENAME_BUILDDATE/"; then
+            echo "[ERROR] Failed to stage transparent-singularity for $IMAGENAME_BUILDDATE. Aborting transaction."
+            abort_cvmfs_transaction neurodesk.ardc.edu.au
+            continue
+        fi
 
-            # check if $IMAGENAME_BUILDDATE variable is not empty:
-            if [[ -n "$IMAGENAME_BUILDDATE" ]]; then
-                cd $IMAGENAME_BUILDDATE
-                export SINGULARITY_BINDPATH=/cvmfs
-                echo $PATH
-                export PATH=$PATH:/usr/sbin/
-                # stdin is log.txt inside this loop; keep child processes from consuming it
-                ./run_transparent_singularity.sh $IMAGENAME_BUILDDATE --unpack true < /dev/null
-                retVal=$?
+        # check if $IMAGENAME_BUILDDATE variable is not empty:
+        if [[ -n "$IMAGENAME_BUILDDATE" ]]; then
+            cd "$IMAGENAME_BUILDDATE"
+            export SINGULARITY_BINDPATH=/cvmfs
+            echo "$PATH"
+            export PATH=$PATH:/usr/sbin/
+            # stdin is log.txt inside this loop; keep child processes from consuming it
+            ./run_transparent_singularity.sh "$IMAGENAME_BUILDDATE" --unpack true < /dev/null
+            retVal=$?
 
-                if [[ $retVal -eq 0 ]]; then
-                    ensure_nested_catalog_markers_for_container "/cvmfs/neurodesk.ardc.edu.au/containers/$IMAGENAME_BUILDDATE" || retVal=$?
-                fi
-            else
-                echo "[ERROR] IMAGENAME_BUILDDATE is empty"
-                exit 2
-            fi
-
-            if [ $retVal -ne 0 ]; then
-                echo "Error in Transparent singularity. Check the log. Aborting!"
-                abort_cvmfs_transaction neurodesk.ardc.edu.au
-            else
-                publish_cvmfs_transaction neurodesk.ardc.edu.au "added $IMAGENAME_BUILDDATE"
+            if [[ $retVal -eq 0 ]]; then
+                ensure_nested_catalog_markers_for_container "/cvmfs/neurodesk.ardc.edu.au/containers/$IMAGENAME_BUILDDATE" || retVal=$?
             fi
         else
-            echo "[WARNING] ========================================================="
-            echo "[DEBUG] ${IMAGENAME_BUILDDATE}.simg does not exist in nectar cloud"
-            echo "[WARNING] ========================================================="
+            echo "[ERROR] IMAGENAME_BUILDDATE is empty"
+            exit 2
+        fi
+
+        if [ $retVal -ne 0 ]; then
+            echo "Error in Transparent singularity. Check the log. Aborting!"
+            abort_cvmfs_transaction neurodesk.ardc.edu.au
+        else
+            publish_cvmfs_transaction neurodesk.ardc.edu.au "added $IMAGENAME_BUILDDATE"
         fi
     fi
 

--- a/neurodesk/build_menu.py
+++ b/neurodesk/build_menu.py
@@ -9,6 +9,7 @@ from typing import Callable, List, Optional, Text, TextIO
 import xml.etree.ElementTree as et
 from xml.dom import minidom
 import shutil
+import shlex
 import logging
 import distutils.dir_util
 
@@ -240,10 +241,14 @@ class NeurodeskApp:
         self.category = f"{self.category}"
         if self.exec:
             # assumes that executable name is before the dash and after the dash the normal container name and version
-            self.container_name = self.name.split("-")[1]
-            self.exec_name = self.name.split("-")[0] + " " + self.name.split("-")[1].split(" ")[1]
-        else: 
-            self.container_name = self.name
+            display_name, container_spec = self.name.split("-", 1)
+            self.container_name, self.container_version = container_spec.rsplit(" ", 1)
+            self.exec_name = f"{display_name} {self.container_version}"
+        else:
+            if " " in self.name:
+                self.container_name, self.container_version = self.name.rsplit(" ", 1)
+            else:
+                self.container_name, self.container_version = self.name, ""
             self.exec_name = self.name
 
     def add_app_sh(self, sh_exec=""):
@@ -257,9 +262,17 @@ class NeurodeskApp:
             if sh_exec:
                 self_sh_file.write(f"{sh_exec}")
             elif self.deskenv == 'mate':
-                self_sh_file.write(f"{str(fetch_and_run_sh)} {self.container_name} {self.exec} \"$@\"")
+                self_sh_file.write(
+                    f"{shlex.quote(str(fetch_and_run_sh))} "
+                    f"{shlex.quote(self.container_name)} {shlex.quote(self.container_version)} "
+                    f"{shlex.quote(self.exec)} \"$@\""
+                )
             else:
-                self_sh_file.write(f"{str(fetch_and_run_sh)} {self.container_name} {self.exec} \"$@\"")
+                self_sh_file.write(
+                    f"{shlex.quote(str(fetch_and_run_sh))} "
+                    f"{shlex.quote(self.container_name)} {shlex.quote(self.container_version)} "
+                    f"{shlex.quote(self.exec)} \"$@\""
+                )
             self_sh_file.write('\n')
         writefile_with_mode(self.sh_path, _write_app_sh, mode=0o755)
 

--- a/neurodesk/build_menu.py
+++ b/neurodesk/build_menu.py
@@ -261,18 +261,16 @@ class NeurodeskApp:
             self_sh_file.write(f"{self.sh_prefix} ")
             if sh_exec:
                 self_sh_file.write(f"{sh_exec}")
-            elif self.deskenv == 'mate':
-                self_sh_file.write(
-                    f"{shlex.quote(str(fetch_and_run_sh))} "
-                    f"{shlex.quote(self.container_name)} {shlex.quote(self.container_version)} "
-                    f"{shlex.quote(self.exec)} \"$@\""
-                )
             else:
-                self_sh_file.write(
-                    f"{shlex.quote(str(fetch_and_run_sh))} "
-                    f"{shlex.quote(self.container_name)} {shlex.quote(self.container_version)} "
-                    f"{shlex.quote(self.exec)} \"$@\""
-                )
+                launcher_args = [
+                    shlex.quote(str(fetch_and_run_sh)),
+                    shlex.quote(self.container_name),
+                    shlex.quote(self.container_version),
+                ]
+                if self.exec:
+                    launcher_args.append(shlex.quote(self.exec))
+                launcher_args.append('"$@"')
+                self_sh_file.write(" ".join(launcher_args))
             self_sh_file.write('\n')
         writefile_with_mode(self.sh_path, _write_app_sh, mode=0o755)
 

--- a/neurodesk/build_menu.py
+++ b/neurodesk/build_menu.py
@@ -268,7 +268,9 @@ class NeurodeskApp:
                     shlex.quote(self.container_version),
                 ]
                 if self.exec:
-                    launcher_args.append(shlex.quote(self.exec))
+                    launcher_args.extend(
+                        shlex.quote(argument) for argument in shlex.split(self.exec)
+                    )
                 launcher_args.append('"$@"')
                 self_sh_file.write(" ".join(launcher_args))
             self_sh_file.write('\n')

--- a/neurodesk/transparent-singularity/run_transparent_singularity.sh
+++ b/neurodesk/transparent-singularity/run_transparent_singularity.sh
@@ -162,23 +162,27 @@ if [ -z "$container" ]; then
       echo "-------------------------------------"
 fi
 
-containerName="$(cut -d'_' -f1 <<< ${container})"
+containerFile="${container##*/}"
+if [[ "$containerFile" == *.simg ]]; then
+   containerEnding="simg"
+   containerStem="${containerFile%.simg}"
+else
+   containerEnding="simg"
+   containerStem="$containerFile"
+fi
+
+containerDate="${containerStem##*_}"
+containerNameAndVersion="${containerStem%_*}"
+containerVersion="${containerNameAndVersion##*_}"
+containerName="${containerNameAndVersion%_*}"
 echo "containerName: ${containerName}"
 
-containerVersion="$(cut -d'_' -f2 <<< ${container})"
 echo "containerVersion: ${containerVersion}"
-
-containerDateAndFileEnding="$(cut -d'_' -f3 <<< ${container})"
-containerDate="$(cut -d'.' -f1 <<< ${containerDateAndFileEnding})"
-containerEnding="$(cut -d'.' -f2 <<< ${containerDateAndFileEnding})"
 
 echo "containerDate: ${containerDate}"
 
 # if no container extension is given, assume .simg
-if [ "$containerEnding" = "$containerDate" ]; then
-   containerEnding="simg"
-   container=${containerName}_${containerVersion}_${containerDate}.${containerEnding}
-fi
+container=${containerStem}.${containerEnding}
 echo "containerEnding: ${containerEnding}"
 
 if [[ -z "$containerName" ]] || [[ -z "$containerVersion" ]] || [[ ! "$containerDate" =~ ^[0-9]{8}$ ]]; then
@@ -411,8 +415,8 @@ if ! singularity exec $singularity_opts --pwd $_base $container $_base/ts_binary
    fail "Could not inspect executables in container '${container}'. Not creating wrapper or module files."
 fi
 
-if [[ ! -f "$_base/commands.txt" ]]; then
-   fail "ts_binaryFinder.sh did not create commands.txt for '${container}'. Not creating wrapper or module files."
+if [[ ! -s "$_base/commands.txt" ]]; then
+   fail "ts_binaryFinder.sh did not create a non-empty commands.txt for '${container}'. Not creating wrapper or module files."
 fi
 
 if [[ ! -f "$_base/env.txt" ]]; then
@@ -479,15 +483,15 @@ chmod a+x deactivate_${container}.sh
 
 # e.g. export container=matlab_2024b_20250117
 echo "create module files one directory up"
-modulePath=$_base/../modules/`echo $container | cut -d _ -f 1`
+modulePath="$_base/../modules/${containerName}"
 echo $modulePath
 # e.g. ../modules/matlab
 mkdir -p "$modulePath"
 
-moduleSoftwareName=`echo $container | cut -d _ -f 1`
+moduleSoftwareName="${containerName}"
 # e.g. matlab
 
-moduleName=`echo $container | cut -d _ -f 2`
+moduleName="${containerVersion}"
 # e.g. 2024b
 
 echo "-- -*- lua -*-" > ${modulePath}/${moduleName}.lua

--- a/neurodesk/write_log.py
+++ b/neurodesk/write_log.py
@@ -11,6 +11,22 @@ def app_log_data(app_data: dict) -> dict:
     return {key: app_data[key] for key in APP_LOG_KWARGS if key in app_data}
 
 
+def is_primary_container_app(menu_name: Text, app_name: Text) -> bool:
+    """Return whether an app entry represents the container itself.
+
+    GUI sub-apps conventionally use ``<label>-<container> <version>``. Concrete
+    container names may themselves contain hyphens, so a dash alone cannot
+    distinguish a sub-app from a primary entry.
+    """
+    if "-" not in app_name:
+        return True
+    container_and_version = app_name.rsplit(" ", 1)
+    return (
+        len(container_and_version) == 2
+        and container_and_version[0] == menu_name
+    )
+
+
 def add_app(
     name: Text,
     version: Text,
@@ -52,6 +68,6 @@ if __name__ == "__main__":
             category_list = ''
             for category in menu_data.get("categories") or []:
                 category_list = category_list + category + ','
-            # Add application, but only if it's not a sub-program of a main container - indicated by dash in program name
-            if not "-" in (app_name):
+            # Add the primary container entry, not its GUI sub-programs.
+            if is_primary_container_app(menu_name, app_name):
                 add_app(app_name, category=category_list, **app_log_data(app_data))

--- a/test/test_build_menu_mimetypes.py
+++ b/test/test_build_menu_mimetypes.py
@@ -52,3 +52,9 @@ def test_wrapper_script_quotes_forwarded_args(tmp_path):
     app = make_app(tmp_path, "libreofficeWriterGUI-libreoffice 26.2.4", "lowriter")
     sh_content = Path(app.sh_path).read_text()
     assert '"$@"' in sh_content
+
+
+def test_wrapper_script_preserves_named_variant_container(tmp_path):
+    app = make_app(tmp_path, "viewerGUI-tool_arm64 1.2.3", "viewer")
+    sh_content = Path(app.sh_path).read_text()
+    assert " tool_arm64 1.2.3 viewer" in sh_content

--- a/test/test_build_menu_mimetypes.py
+++ b/test/test_build_menu_mimetypes.py
@@ -1,5 +1,6 @@
 import configparser
 from pathlib import Path
+import shlex
 
 from neurodesk.build_menu import EXEC_MIMETYPES, NeurodeskApp
 
@@ -52,6 +53,24 @@ def test_wrapper_script_quotes_forwarded_args(tmp_path):
     app = make_app(tmp_path, "libreofficeWriterGUI-libreoffice 26.2.4", "lowriter")
     sh_content = Path(app.sh_path).read_text()
     assert '"$@"' in sh_content
+
+
+def test_wrapper_script_preserves_multiword_exec_arguments(tmp_path):
+    app = make_app(
+        tmp_path,
+        "cat12GUI-cat12 12.9",
+        "bash run_spm12.sh /opt/mcr/v93/",
+    )
+    command = Path(app.sh_path).read_text().splitlines()[1]
+
+    assert shlex.split(command)[-6:] == [
+        "cat12",
+        "12.9",
+        "bash",
+        "run_spm12.sh",
+        "/opt/mcr/v93/",
+        "$@",
+    ]
 
 
 def test_wrapper_script_preserves_named_variant_container(tmp_path):

--- a/test/test_build_menu_mimetypes.py
+++ b/test/test_build_menu_mimetypes.py
@@ -58,3 +58,10 @@ def test_wrapper_script_preserves_named_variant_container(tmp_path):
     app = make_app(tmp_path, "viewerGUI-tool_arm64 1.2.3", "viewer")
     sh_content = Path(app.sh_path).read_text()
     assert " tool_arm64 1.2.3 viewer" in sh_content
+
+
+def test_wrapper_script_omits_empty_exec_argument(tmp_path):
+    app = make_app(tmp_path, "tool_arm64 1.2.3", "")
+    command = Path(app.sh_path).read_text().splitlines()[1]
+    assert command.endswith('fetch_and_run.sh tool_arm64 1.2.3 "$@"')
+    assert "''" not in command

--- a/test/test_cleanup_stale_containers.py
+++ b/test/test_cleanup_stale_containers.py
@@ -1,0 +1,39 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / ".github" / "workflows" / "scripts" / "cleanup_stale_containers.py"
+
+spec = importlib.util.spec_from_file_location("cleanup_stale_containers", SCRIPT)
+cleanup = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cleanup)
+
+
+def test_release_metadata_protects_named_and_legacy_images(tmp_path):
+    releases = tmp_path / "releases"
+
+    named = releases / "workshopdemo_arm64" / "1.0.0.json"
+    named.parent.mkdir(parents=True)
+    named.write_text(json.dumps({"apps": {"workshopdemo_arm64 1.0.0": {"version": "20260721"}}}))
+
+    legacy = releases / "amico" / "2.1.0-arm64.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(
+        json.dumps(
+            {
+                "apps": {
+                    "amico 2.1.0 arm64": {
+                        "version": "20260512",
+                        "image": "amico_2.1.0_arm64",
+                    }
+                }
+            }
+        )
+    )
+
+    assert cleanup.load_release_keys(releases) == {
+        "workshopdemo_arm64_1.0.0_20260721.simg",
+        "amico_2.1.0_arm64_20260512.simg",
+    }

--- a/test/test_cleanup_stale_containers.py
+++ b/test/test_cleanup_stale_containers.py
@@ -2,6 +2,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / ".github" / "workflows" / "scripts" / "cleanup_stale_containers.py"
@@ -37,3 +39,22 @@ def test_release_metadata_protects_named_and_legacy_images(tmp_path):
         "workshopdemo_arm64_1.0.0_20260721.simg",
         "amico_2.1.0_arm64_20260512.simg",
     }
+
+
+@pytest.mark.parametrize(
+    "release",
+    [
+        {},
+        {"apps": []},
+        {"apps": {"demo 1.0": []}},
+        {"apps": {"demo 1.0": {"version": "latest"}}},
+        {"apps": {"demo 1.0": {"version": "20260721", "image": ""}}},
+    ],
+)
+def test_invalid_release_metadata_aborts_cleanup(tmp_path, release):
+    release_path = tmp_path / "releases" / "demo" / "1.0.json"
+    release_path.parent.mkdir(parents=True)
+    release_path.write_text(json.dumps(release))
+
+    with pytest.raises(SystemExit, match="Invalid release metadata"):
+        cleanup.load_release_keys(tmp_path / "releases")

--- a/test/test_cvmfs_generated_metadata.py
+++ b/test/test_cvmfs_generated_metadata.py
@@ -32,5 +32,13 @@ def test_stratum_sync_publishes_log_and_applist_together():
     assert 'git -C "$repo_path" add "${generated_rel_paths[@]}"' in script
 
 
+def test_stratum_sync_uses_tested_retrieval_scripts_without_nectar_gate():
+    script = SYNC_SCRIPT.read_text()
+
+    assert 'cp -a "$NEUROCOMMAND_LOCAL_REPO/neurodesk/transparent-singularity/."' in script
+    assert "git clone https://github.com/NeuroDesk/transparent-singularity" not in script
+    assert "object-store.rc.nectar.org.au" not in script
+
+
 def test_stratum_sync_script_is_valid_bash():
     subprocess.run(["bash", "-n", str(SYNC_SCRIPT)], check=True)

--- a/test/test_cvmfs_reconcile_module_files.py
+++ b/test/test_cvmfs_reconcile_module_files.py
@@ -30,6 +30,12 @@ def make_container(repo_root, container_name, commands="datalad\n"):
     (container / "commands.txt").write_text(commands)
 
 
+def test_parse_image_name_supports_named_variants():
+    assert reconcile_module_files.parse_image_name(
+        "fsl_gpu_arm64_6.0.7_20260721.simg"
+    ) == ("fsl_gpu_arm64", "6.0.7", "20260721")
+
+
 def test_reconciles_current_public_modules_and_removes_stale_categories(tmp_path):
     repo_root = tmp_path / "cvmfs" / "neurodesk.ardc.edu.au"
     old_container = "datalad_1.3.1_20260227"

--- a/test/test_run_transparent_singularity.py
+++ b/test/test_run_transparent_singularity.py
@@ -21,7 +21,7 @@ def test_oras_pull_failure_falls_back_to_nectar(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     calls = tmp_path / "calls.log"
-    container = "demo_1.0_20260629.simg"
+    container = "demo_arm64_1.0_20260629.simg"
 
     write_executable(
         bin_dir / "apptainer",
@@ -46,12 +46,12 @@ def test_oras_pull_failure_falls_back_to_nectar(tmp_path):
             exit 0
         fi
 
-        if [[ "$args" == *"ghcr.io/v2/neurodesk/demo/manifests/1.0_20260629"* && "$args" == *"-sIL"* ]]; then
+        if [[ "$args" == *"ghcr.io/v2/neurodesk/demo_arm64/manifests/1.0_20260629"* && "$args" == *"-sIL"* ]]; then
             printf 'HTTP/1.1 200 OK\\r\\nDocker-Content-Digest: sha256:docker\\r\\n\\r\\n'
             exit 0
         fi
 
-        if [[ "$args" == *"ghcr.io/v2/neurodesk/demo/manifests/sha256-docker"* ]]; then
+        if [[ "$args" == *"ghcr.io/v2/neurodesk/demo_arm64/manifests/sha256-docker"* ]]; then
             echo '{{"manifests":[{{"artifactType":"application/vnd.sylabs.sif.layer.v1.sif","digest":"sha256:sif"}}]}}'
             exit 0
         fi
@@ -154,15 +154,15 @@ def test_oras_pull_failure_falls_back_to_nectar(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
     call_log = calls.read_text()
     assert (
-        "apptainer pull --name demo_1.0_20260629.simg "
-        "oras://ghcr.io/neurodesk/demo@sha256:sif"
+        "apptainer pull --name demo_arm64_1.0_20260629.simg "
+        "oras://ghcr.io/neurodesk/demo_arm64@sha256:sif"
     ) in call_log
     assert (
-        "nectar-download demo_1.0_20260629.simg "
+        "nectar-download demo_arm64_1.0_20260629.simg "
         "https://object-store.rc.nectar.org.au/v1/"
     ) in call_log
-    assert (workdir / "demo_1.0_20260629.simg").is_dir()
-    module_file = tmp_path / "modules" / "demo" / "1.0.lua"
+    assert (workdir / "demo_arm64_1.0_20260629.simg").is_dir()
+    module_file = tmp_path / "modules" / "demo_arm64" / "1.0.lua"
     assert module_file.is_file()
     module_text = module_file.read_text()
     assert "-- neurodesk-exposed-commands" in module_text

--- a/test/test_write_log.py
+++ b/test/test_write_log.py
@@ -1,0 +1,11 @@
+from neurodesk.write_log import is_primary_container_app
+
+
+def test_hyphenated_named_variant_is_a_primary_container_app():
+    assert is_primary_container_app(
+        "neurodesktop-lite_arm64", "neurodesktop-lite_arm64 20260428"
+    )
+
+
+def test_gui_sub_app_is_not_a_primary_container_app():
+    assert not is_primary_container_app("fsl", "fsleyesGUI-fsl 6.0.7.22")


### PR DESCRIPTION
## Summary

- parse container names from the right so concrete names such as `fsl_gpu_arm64` survive launcher generation, CVMFS deployment, and module reconciliation
- generate correctly quoted launcher arguments without passing an empty command for shell-launch entries
- include primary containers whose concrete names contain hyphens in the CVMFS deployment log while continuing to exclude GUI sub-apps
- require a non-empty command set before creating wrappers/modules
- protect every image referenced by neurocontainers release metadata from stale-container cleanup
- preserve the newer Lmod extension metadata when reconciling named-variant modules

## Current rollout

neurodesk/neurocontainers#2913 has merged, and named ARM64 releases are now being published through the normal release path. The current catalogue contains `neurodesktop-lite_arm64 20260428` with build date `20260808`; this change makes that concrete identity eligible for the normal CVMFS deployment path.

This PR supersedes #777 as the actual implementation. The larger manifest-backed distribution redesign is not required for named variants to work end to end.

## Validation

- 79 neurocommand tests pass on Python 3.12
- cleanup and log-selection tests pass on Python 3.8
- shell syntax validation passes
- cleanup workflow YAML parses successfully
- generated log contains `neurodesktop-lite_arm64_20260428_20260808` and excludes GUI sub-apps
- simulated `demo_arm64` registry failure, Nectar fallback, extraction, module generation, and Lmod extension generation pass

Closes #733.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for container and application names containing underscores, hyphens, and architecture-specific variants.
  - Improved launcher argument handling, quoting, and omission of empty executables.
  - Required non-empty command definitions for transparent container launches.
  - Prevented cleanup from removing images referenced by release metadata.
  - Improved detection of primary applications versus GUI sub-applications.
  - Improved container synchronization and recovery from incomplete container directories.

- **Tests**
  - Added regression coverage for release protection, filename parsing, launcher generation, synchronization, and application classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up

- preserve multi-word launcher commands as separate quoted arguments
- abort stale-container cleanup when release metadata is malformed instead of silently dropping protection
- let CVMFS retrieval use every supported backend and stage the exact vendored transparent-singularity scripts tested by this PR
