### PR TITLE
Propose manifest-backed container distribution

### DIFF
--- a/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
+++ b/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
@@ -40,10 +40,11 @@ The important distinction is that a Neurodesk product **flavour** such as
 Architecture selection belongs in the OCI image index. Product flavour remains
 an explicit release dimension and, where necessary, an OCI tag dimension.
 
-The recommended rollout is additive. New and legacy paths and tags should be
-published together until Neurocommand, Neurodesktop, external HPC module users,
-and maintenance jobs have moved to the manifest-backed resolver. No existing
-container should be moved or deleted as the first step.
+The recommended change is delivered as one coordinated merge train. The new
+resolver, manifest producer, CVMFS layout, and legacy compatibility views land
+together through linked PRs. New and legacy paths and tags are published in the
+same release, resolve to the same content, and this change does not move or
+delete any existing container.
 
 ## Proposed decisions
 
@@ -84,8 +85,12 @@ container should be moved or deleted as the first step.
    reference.
 
 8. Generate `apps.json`, CVMFS inventory, modulefiles, cleanup keep-lists, and
-   application lists from release manifests. `cvmfs/log.txt` can remain as a
-   compatibility output during migration, but not as the source of truth.
+   application lists from release manifests. `cvmfs/log.txt` remains a
+   compatibility output for existing consumers, but not the source of truth.
+
+9. Make the complete existing CVMFS pathname a required compatibility view for
+   every release published in the new layout. Supporting the old resolver alone
+   is insufficient because external users may have stored direct paths.
 
 ## Motivation
 
@@ -188,7 +193,7 @@ boundary and avoids putting every release directly in the large
 
 `software_version` is the upstream tool version, not the container build date.
 The existing release JSON field named `version` inside an app currently stores
-the build date, so the new schema must use unambiguous names during migration:
+the build date, so the new schema must use unambiguous names:
 
 ```json
 {
@@ -334,6 +339,43 @@ Each release directory is immutable after a successful publish.
 Additional generated files such as environment metadata may remain in the
 release root, but every field used to regenerate them must be present in
 `release.json`.
+
+### Required legacy path view
+
+For every canonical release, the same CVMFS transaction must publish its exact
+legacy directory and inner `.simg` pathname. For example:
+
+```text
+/containers/fsl_6.0.7.16_20260728/
+└── fsl_6.0.7.16_20260728.simg/
+
+/containers/fsl/6.0.7.16_amd64_20260728/
+└── rootfs/
+```
+
+Both paths must expose the same rootfs content. The legacy name is derived from
+explicit manifest compatibility fields, not reconstructed by splitting the new
+path. ARM and flavour aliases are equally explicit, for example:
+
+```text
+/containers/fsl_arm64_6.0.7.16_20260728/
+  -> /containers/fsl/6.0.7.16_arm64_20260728/
+```
+
+Operationally this is a hard-linked compatibility view: there is one payload
+and two stable namespaces. It cannot be implemented as a literal POSIX hard
+link between the directory trees because directories cannot be hard-linked and
+CVMFS emulates file hard-link groups only within one directory. The publisher
+should therefore use directory and inner-name symlinks where the old client
+tests permit them. If a materialized mirror is required, its regular-file
+entries must have the same CVMFS content hashes as the canonical tree; CVMFS
+content-addressed storage then avoids duplicating payload blobs even though
+both namespaces consume catalog entries.
+
+Publication fails if an expected legacy pathname is absent, resolves outside
+its declared canonical release, or does not expose the same content. Existing
+materialized legacy releases are left untouched rather than rewritten into
+aliases.
 
 ### Catalog boundaries
 
@@ -581,11 +623,17 @@ This is a discussion schema, not a final JSON Schema:
     "platforms": {
       "linux/amd64": {
         "variant": "amd64",
-        "path": "containers/fsl/6.0.7.16_amd64_20260728"
+        "path": "containers/fsl/6.0.7.16_amd64_20260728",
+        "legacy_rootfs_paths": [
+          "containers/fsl_6.0.7.16_20260728/fsl_6.0.7.16_20260728.simg"
+        ]
       },
       "linux/arm64": {
         "variant": "arm64",
-        "path": "containers/fsl/6.0.7.16_arm64_20260728"
+        "path": "containers/fsl/6.0.7.16_arm64_20260728",
+        "legacy_rootfs_paths": [
+          "containers/fsl_arm64_6.0.7.16_20260728/fsl_arm64_6.0.7.16_20260728.simg"
+        ]
       }
     }
   },
@@ -647,8 +695,8 @@ At runtime:
 4. If the recorded CVMFS release and `rootfs` exist, it executes that release.
 5. Otherwise it resolves the recorded OCI index and child digest, discovers the
    exact SIF referrer, verifies it, and pulls it to local storage.
-6. Object-storage URLs and legacy OCI layouts remain last-resort migration
-   fallbacks only.
+6. Object-storage URLs and legacy OCI layouts remain last-resort compatibility
+   fallbacks for releases without a valid manifest.
 
 This same resolver should be used by:
 
@@ -713,7 +761,8 @@ Neurocommand owns materialization and client resolution:
 - resolve local, CVMFS, and OCI locations;
 - select host platform and requested flavour;
 - verify OCI subjects and SIF digests;
-- retain legacy local/object-store fallbacks during migration;
+- retain legacy local/object-store fallbacks without removing them in this
+  change;
 - drive cleanup from release state and retention policy; and
 - report actionable diagnostics.
 
@@ -866,125 +915,164 @@ the same OCI subject graph without another naming scheme. The manifest schema
 should reserve typed referrer entries for signatures, SBOMs, provenance, and
 security scan results.
 
-## Migration plan
+## Coordinated merge plan
 
-### Phase 0: ratify the contract
+This is one cross-repository change, not a sequence of independently deployed
+states. The implementation PRs can be reviewed independently, but they remain
+draft and are validated together at their exact head commits. They are merged
+in one scheduled window only when the complete set is ready.
 
-- Decide the open questions at the end of this document.
-- Check in a versioned release JSON Schema.
-- Audit current recipe names and versions against the proposed character rules.
-- Decide how PRs #2913 and #2914 will be integrated.
-- Freeze new one-off filename parsers while the resolver is implemented.
+### Linked PR set
 
-Exit criterion: maintainers approve the identity tuple, CVMFS variant rule, OCI
-tag rule, referrer subject rule, and registry priority.
+| Order | Repository | PR contents | Merge condition |
+|---|---|---|---|
+| 1 | `neurodesk/neurocommand` | Versioned schema consumer, manifest resolver, new and legacy CVMFS views, generated metadata, modules, cleanup reachability, and compatibility tests. The resolver uses the legacy path whenever a complete valid schema-v1 manifest is absent. | Required; safe and dormant before the producer PR merges. |
+| 2 | `neurodesk/neurodesktop` | Consume the resolver for startup and integration tests; remove hard-coded flat container and module paths. | Expected from the current code audit. Omit only if the cross-repository test proves Neurodesktop needs no source change. |
+| 3 | `neurodesk/neurocontainers` | Integrate the variant fan-out from #2913 with the tested candidate promotion from #2914; produce the canonical manifest, multi-platform index, SIF referrers, and immutable release history. | Required and merged last because a valid published manifest activates the new path. |
 
-### Phase 1: generate manifests without changing publication
+This proposal PR, `neurodesk/neurocommand#777`, is the tracker and contract
+review. Every implementation PR body must contain:
 
-- Extend the one-PR candidate manifest with flavour and platform.
-- Preserve release history by build date.
-- Generate the proposed canonical manifest alongside current release JSON.
-- Validate equivalence between the manifest and legacy image/SIF names.
-- Generate `apps.json`, `log.txt`, and cleanup keep-lists from the new manifest
-  in check-only mode.
+```text
+Part of neurodesk/neurocommand#777
+Depends on <exact linked PR URLs>
+Merge order: neurocommand -> neurodesktop (if required) -> neurocontainers
+```
 
-Exit criterion: generated legacy outputs are byte-equivalent or have reviewed
-diffs for a representative set of default, GUI, ARM, and hidden releases.
+The bodies also link #2913 and #2914 and state whether they are integrated,
+superseded, or must be rebased. A PR must not claim the coordinated change is
+ready while one of its required links is missing or still failing.
 
-### Phase 2: publish the OCI graph
+### Cross-repository contract
 
-- Build and test all required platform children for a flavour.
-- Push immutable child manifests.
-- Create and verify the OCI image index.
-- Attach each tested SIF to its child manifest.
-- Attach the canonical release manifest to the index.
-- Copy and verify the full subject graph in each supported registry.
-- Advance floating tags last.
+- The linked PRs use the same schema version, identity rules, fixtures, and
+  expected digests. The CI record identifies every tested PR head SHA.
+- Capability detection is data-driven, not a manually coordinated feature
+  flag. Neurocommand selects the new path only for a complete schema-v1
+  manifest that passes schema, identity, subject, platform, and digest checks;
+  otherwise it follows the existing path.
+- New and legacy paths, module views, tags, and generated metadata are outputs
+  of the same canonical release manifest.
+- Existing flat CVMFS paths, OCI tags, and object-store SIFs are retained. Their
+  removal is outside this linked PR set and requires a separate proposal based
+  on usage data and the supported-client policy.
+- Every canonical CVMFS release has its complete legacy directory and inner
+  `.simg` pathname in the same transaction. Both namespaces resolve to the same
+  content hashes.
+- No new code outside the explicit compatibility adapter derives identity by
+  splitting filenames, display labels, OCI repositories, or CVMFS paths.
+- Cleanup is disabled for the new identity until reachability tests cover both
+  views. Nothing in this change makes legacy content eligible for deletion.
 
-Exit criterion: a standalone resolver can select and pull exact AMD64 and ARM64
-SIFs by manifest on both the primary registry and its fallback.
+### Pre-merge proof
 
-### Phase 3: dual-publish CVMFS
+A cross-repository CI or reproducible maintainer run checks out the exact heads
+of all linked PRs and builds one representative release graph. It must cover:
 
-- Materialize the new `/containers/<name>/<release>` tree.
-- Keep the old flat tree during the pilot.
-- Generate both old and new module views.
-- Add per-release nested catalogs and inspect their entry counts.
-- Make publication idempotent and abort cleanly on a failed verification.
+- a default AMD64 and ARM64 release from one logical tool name;
+- one non-default flavour such as `gpu`;
+- schema rejection and fallback when the manifest is missing, incomplete, or
+  has an unexpected version;
+- SIF selection by child digest with native referrers and the documented
+  fallback-tag scheme;
+- CVMFS enabled and disabled, local/offline reuse, module loading, CLI and GUI
+  wrappers, and Neurodesktop startup;
+- primary-registry failure and verified fallback;
+- generation of `apps.json`, `log.txt`, modulefiles, new paths, and legacy
+  compatibility paths from the same manifest;
+- an old Neurocommand/Neurodesktop client running the compatibility path;
+- every declared `legacy_rootfs_paths` entry working directly without a
+  resolver and exposing the canonical rootfs content hash; and
+- dry-run cleanup proving active, hidden, compatibility, and retained releases
+  remain reachable.
 
-To avoid duplicating rootfs catalog entries, test a compatibility alias such as:
+The resulting manifest, digests, generated-file diff, CVMFS path listing, and
+test results are attached to or linked from every required PR. Testing branch
+names or moving default branches is insufficient; the evidence must name the
+commit SHAs that will merge.
+
+### Atomic activation
+
+GitHub, OCI registries, and CVMFS do not share a distributed transaction.
+Atomicity here means no client can select an incomplete release: the canonical
+manifest is the activation record, it is published only after the OCI graph is
+complete, and absence of the CVMFS path sends the resolver to the digest-pinned
+OCI artifact.
+
+The OCI publisher may push immutable candidate blobs and child manifests while
+testing, because those objects do not activate a release. It then:
+
+1. verifies every required flavour/platform child and SIF;
+2. creates and verifies the image index and referrer graph;
+3. records registry-resolved digests in the canonical release manifest;
+4. publishes that immutable manifest; and
+5. advances convenience/floating pointers last.
+
+A failure before the final two steps leaves only unreachable immutable
+candidates and does not expose a partial release to clients.
+
+CVMFS publication uses one repository transaction. Within it, Neurocommand
+materializes `/containers/<name>/<version>_<variant>_<builddate>`, generates the
+new module view, and creates or preserves the required legacy compatibility
+view. It validates the rootfs, commands, release manifest, modules, paths, and
+legacy resolution before publishing the transaction. On failure it aborts the
+transaction, leaving the previous CVMFS revision visible.
+
+For example, a tested directory alias may be:
 
 ```text
 /containers/fsl_6.0.7.16_20260728
   -> /containers/fsl/6.0.7.16_amd64_20260728
 ```
 
-The target release may temporarily include the expected legacy inner name as a
-symlink to `rootfs`. Do not replace an existing materialized legacy catalog with
-this alias until Apptainer, CVMFS, module, and old-client tests pass. CVMFS
-content hashing reduces duplicate blob storage during a short dual-materialized
-period, but duplicate catalog entries still have a cost.
+The canonical release must also expose the legacy inner
+`fsl_6.0.7.16_20260728.simg` name as a view of `rootfs` so the complete stored
+path continues to work. An existing materialized legacy path is never replaced
+merely to introduce the alias. The linked PR test must prove the selected
+representation works through Apptainer, CVMFS, modules, an old client, and a
+direct legacy pathname with no resolver involved.
 
-Exit criterion: legacy and new clients run the same pilot digest from the same
-CVMFS revision.
+### Merge window and go/no-go
 
-### Phase 4: migrate consumers
+Merge in the table order during one scheduled window. Earlier PRs contain
+backwards-compatible consumers only; the Neurocontainers producer is the
+activation boundary and merges last. If the expected Neurodesktop change is
+unnecessary, record the test evidence on the tracker rather than opening an
+empty coordination PR.
 
-- Move `fetch_and_run.sh`, `fetch_containers.sh`, and menu wrappers to release
-  IDs.
-- Move module reconciliation to manifest fields.
-- Move Neurodesktop integration tests to the resolver.
-- Move fulltests and CVMFS preflight to the shared resolver.
-- Move cleanup and DOI jobs to canonical identity fields.
-- Change diagnostics to print release ID, platform, CVMFS path, OCI subject, and
-  SIF digest.
+The merge proceeds only when:
 
-Exit criterion: repository searches find flat-name construction only in the
-legacy compatibility layer and its tests.
+- the contract decisions below are approved;
+- all required PRs approve and pin the same contract;
+- all repository-local and exact-head cross-repository checks pass;
+- the OCI candidate graph and CVMFS transaction both pass preflight;
+- legacy clients resolve the same tested digest through the compatibility view;
+- previous OCI pointer digests and the previous CVMFS revision are recorded;
+- destructive cleanup and legacy removal are absent; and
+- maintainers for every affected repository confirm the merge order and window.
 
-### Phase 5: pilot and cut over
-
-Suggested pilots:
-
-1. `dcm2niix` or `niimath` for a small default multi-architecture release.
-2. A GUI-bearing container to validate menu generation.
-3. A GPU flavour after the two-platform default path is stable.
-
-For each pilot test:
-
-- AMD64 with CVMFS enabled;
-- ARM64 with CVMFS enabled;
-- both architectures with CVMFS disabled and OCI pull enabled;
-- local/offline reuse;
-- CLI and GUI wrappers;
-- module load and explicit flavour selection;
-- primary-registry failure and fallback;
-- native referrers and tag-schema fallback;
-- withdrawn/stale release handling; and
-- Neurodesktop startup and its container test suite.
-
-After a published compatibility window:
-
-- stop generating new flat directories;
-- retain aliases for an agreed longer window;
-- remove filename parsing from normal resolution;
-- remove object-store fallback only after usage is measured; and
-- document the final removal release.
+Any failed condition stops the whole merge train. It does not create another
+deployment state to support.
 
 ## Rollback
 
-Every migration phase must remain reversible:
+Rollback changes pointers and generated views; it does not rebuild, overwrite,
+or delete immutable content:
 
-- immutable legacy OCI tags and SIF objects are retained;
-- legacy CVMFS paths remain materialized or aliased;
-- `apps.json` can point launchers back to the legacy resolver;
-- floating tags can be restored to their previous recorded digests;
-- a failed new CVMFS publish is aborted before the compatibility view changes;
-  and
-- no cleanup of legacy objects occurs until after the compatibility window.
+- before activation, do not merge the producer PR and revert any already-merged
+  consumer PR only if necessary;
+- restore floating OCI pointers to their recorded previous digests;
+- remove or withdraw the activating canonical manifest from generated release
+  state so capability detection returns consumers to the legacy resolver;
+- restore the previous generated `apps.json` and module views;
+- abort an unpublished CVMFS transaction or restore the recorded previous
+  revision after publication; and
+- retain immutable legacy OCI tags, SIF objects, and CVMFS paths throughout.
 
-Rollback changes pointers and generated views. It does not rebuild or overwrite
-immutable content.
+Because consumers automatically fall back when no valid schema-v1 manifest is
+present, producer rollback does not require rebuilding a container or an
+emergency consumer release. Investigation can use the immutable candidate
+objects without exposing them as an active release.
 
 ## Validation requirements
 
@@ -1010,6 +1098,7 @@ immutable content.
 - Native referrers, fallback-tag, missing-referrer, multiple-referrer,
   wrong-subject, wrong-platform, and bad-digest tests.
 - Module generation without a hard-coded mount path.
+- Exact legacy-path generation and canonical-content equivalence tests.
 - Empty deploy command rejection.
 - Cleanup reachability tests proving hidden and non-active retained releases are
   not deleted.
@@ -1049,7 +1138,7 @@ Directly relevant items:
 | [neurocontainers#2409](https://github.com/neurodesk/neurocontainers/issues/2409) | OCI labels and SIF annotations. |
 | [neurocontainers#2796](https://github.com/neurodesk/neurocontainers/issues/2796) | Fulltest artifact selection from release metadata. |
 | [neurocontainers#1906](https://github.com/neurodesk/neurocontainers/issues/1906) | CVMFS client configuration distribution; mount configuration remains outside this layout proposal. |
-| [neurocontainers#1253](https://github.com/neurodesk/neurocontainers/issues/1253) | CVMFS metrics; useful for measuring cutover and fallback usage. |
+| [neurocontainers#1253](https://github.com/neurodesk/neurocontainers/issues/1253) | CVMFS metrics; useful for measuring compatibility and fallback usage. |
 | [neurocontainers#61](https://github.com/neurodesk/neurocontainers/issues/61) | CVMFS scanning; the manifest enables structured reconciliation. |
 | [neurocontainers#218](https://github.com/neurodesk/neurocontainers/issues/218) | Container metadata/database direction. |
 | [neurocontainers#504](https://github.com/neurodesk/neurocontainers/issues/504) | Signing and supply-chain metadata fit the OCI subject graph. |
@@ -1069,6 +1158,7 @@ build/release failures and do not change the proposed layout.
 - [ORAS `attach` command](https://oras.land/docs/commands/oras_attach/)
 - [Apptainer OCI registry documentation](https://apptainer.org/docs/user/latest/registry.html)
 - [CVMFS nested catalog recommendations](https://cvmfs.readthedocs.io/en/2.14/cpt-repo/#managing-nested-catalogs)
+- [CVMFS content hashes and hard-link constraints](https://cvmfs.readthedocs.io/en/2.14/cpt-details/#file-catalog)
 - [CVMFS repository integrity checks](https://cvmfs.readthedocs.io/en/stable/cpt-repo.html)
 
 ## Alternatives considered
@@ -1119,13 +1209,13 @@ deleted valid hidden ARM artifacts.
 | How should product flavours appear in OCI? | Separate immutable tags/indexes within the same logical repository. |
 | What is the SIF subject? | The exact platform child manifest. |
 | What is the canonical architecture vocabulary? | OCI `amd64` and `arm64`; accept recipe aliases at input. |
-| What is the unpacked CVMFS payload called? | `rootfs`, with temporary legacy inner-name aliases if required. |
+| What is the unpacked CVMFS payload called? | `rootfs`, with a required legacy inner-name view for every published compatibility alias. |
 | What is the release-history path in Neurocontainers? | `releases/<name>/<version>/<flavour>/<build_date>.json`. |
 | Which registry is primary? | Ratify Quay-primary versus GHCR-critical; record and verify each registry independently meanwhile. |
 | What happens on a conflicting same-day rebuild? | Fail promotion; approve an extended build ID before allowing it. |
 | How does `module load name/version` select architecture? | Use the shared resolver/platform dispatcher; never fix the module to AMD64. |
-| How long are flat CVMFS aliases retained? | At least one announced Neurodesktop/Neurocommand compatibility cycle, then remove based on observed usage. |
-| Is the legacy `.simg` object-store path retained? | Yes during migration and for rollback; measure use before removal. |
+| How long are flat CVMFS aliases retained? | This change sets no removal date. Removal requires a separate proposal based on observed usage and supported-client policy. |
+| Is the legacy `.simg` object-store path retained? | Yes. Its removal is outside this change and requires measured usage plus a separate proposal. |
 
-Approval of those decisions is sufficient to split implementation into
-reviewable PRs without requiring a flag day across the three repositories.
+Approval of those decisions is sufficient to open the linked implementation
+PRs and merge them as one coordinated train across the affected repositories.

--- a/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
+++ b/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
@@ -32,9 +32,9 @@ The change has five non-negotiable properties:
 2. One immutable OCI tag points to an image index, even when the release
    currently has only one platform. Each platform-specific SIF is attached to
    the corresponding child image manifest.
-3. The complete existing CVMFS path remains valid for every newly published
-   release before generated views expose it. Old clients and stored paths do
-   not need to understand manifests.
+3. The release manifest contains no legacy identity. A separate,
+   Neurocommand-only compatibility policy preserves the existing default AMD64
+   flat path; it never synthesizes aliases for a new platform or build variant.
 4. Existing releases are not moved, rewritten, backfilled, or deleted by this
    change.
 5. The implementation is delivered as one coordinated merge train with two
@@ -45,8 +45,8 @@ This deliberately changes the target distribution model described in
 [neurocommand#733](https://github.com/neurodesk/neurocommand/issues/733).
 Neurocontainers may still fan out concrete build candidates such as
 `fsl_gpu_arm64`, but the published manifest keeps logical name, build variant,
-and platform as separate fields. The old concrete name is retained as an
-explicit compatibility identity.
+and platform as separate fields. Candidate names do not automatically become
+public compatibility identities.
 
 ## Scope
 
@@ -54,7 +54,7 @@ explicit compatibility identity.
 
 - the release identity and schema;
 - the new CVMFS release path;
-- the complete legacy CVMFS path for each new release;
+- an isolated compatibility adapter for the existing default AMD64 flat path;
 - multi-platform OCI indexes and platform-specific SIF referrers;
 - immutable release history;
 - manifest-driven `apps.json`, `cvmfs/log.txt`, modules, launchers, publication,
@@ -68,8 +68,9 @@ explicit compatibility identity.
 ### Not included
 
 - converting existing CVMFS releases to the new hierarchy;
-- removing flat CVMFS paths, legacy OCI tags, object-store SIFs, or filename
-  parsing;
+- removing existing flat CVMFS paths, legacy OCI tags, object-store SIFs, or
+  filename parsing;
+- inventing flat identities for new ARM or named-variant releases;
 - changing `/cvmfs/neurodesk.ardc.edu.au`, the public module roots, or
   `module load <name>/<version>`;
 - redesigning the full release-withdrawal or retention policy;
@@ -143,7 +144,7 @@ The document uses these terms precisely:
 | Release | One logical build across its supported platforms | `fsl/6.0.7.16/default/20260728` |
 | Platform artifact | One release plus an OCI platform | release + `linux/arm64` |
 | CVMFS variant | Filesystem projection of build variant and platform | `arm64`, `gpu-amd64` |
-| Legacy identity | Complete concrete name used by existing clients | `fsl_arm64_6.0.7.16_20260728` |
+| Compatibility alias | Existing concrete path explicitly retained for old clients | `fsl_6.0.7.16_20260728` |
 
 The release identity is:
 
@@ -159,6 +160,12 @@ The platform artifact identity is:
 
 This distinction matters. One release manifest and OCI image index can describe
 multiple platform artifacts.
+
+A compatibility alias is not part of either identity and is not stored in the
+release manifest. It is a projection made by a separate Neurocommand policy
+for a demonstrated old-client contract. Canonical producers and consumers
+never infer aliases from `name`, `build_variant`, `platform`, or
+`cvmfs_variant`.
 
 ### Normalization
 
@@ -224,15 +231,19 @@ The inner layout intentionally remains compatible with today's publisher. In
 particular, this proposal does **not** rename the unpacked `.simg` directory to
 `rootfs` or move wrappers into a new `bin` directory. Those changes are not
 needed to introduce the hierarchy and would increase the activation surface.
+Within the canonical hierarchy, every platform uses the logical inner name
+`<name>_<software-version>_<build-date>.simg`; concrete candidate names such as
+`fsl_arm64` and `fsl_gpu` do not propagate into it. The outer release directory
+already disambiguates platform and variant.
 
 The release directory is immutable after publication and is a nested catalog
 root. The current nested catalogs inside the unpacked image are preserved until
 separate measurements justify changing them.
 
-### Required legacy path
+### Isolated compatibility aliases
 
-The same CVMFS transaction creates the canonical directory and the old outer
-name:
+For a new default AMD64 release, the Neurocommand compatibility policy keeps
+the existing flat-path interface. The same CVMFS transaction creates:
 
 ```text
 /containers/fsl_6.0.7.16_20260728
@@ -245,28 +256,38 @@ The complete old path therefore still works:
 /containers/fsl_6.0.7.16_20260728/fsl_6.0.7.16_20260728.simg
 ```
 
-ARM and named variants use manifest-declared legacy identities:
+This does **not** establish a second flat naming scheme. New ARM and named
+variant releases are canonical-only:
 
 ```text
-/containers/fsl_arm64_6.0.7.16_20260728
-  -> fsl/6.0.7.16_arm64_20260728
-
-/containers/fsl_gpu_6.0.7.16_20260728
-  -> fsl/6.0.7.16_gpu-amd64_20260728
+/containers/fsl/6.0.7.16_arm64_20260728/       # canonical only
+/containers/fsl/6.0.7.16_gpu-amd64_20260728/   # canonical only
 ```
 
-This meets the requested hard-link intent—one payload with two stable
-namespaces—but the outer directory must be a symbolic link, not a literal
-hard link. POSIX does not support directory hard links, and CVMFS emulates file
-hard-link groups only within one directory. A directory symlink also avoids
-duplicating catalog entries for the unpacked image.
+In particular, the canonical publisher must not derive `fsl_arm64_*`,
+`fsl_gpu_*`, or similar aliases from manifest axes. If repository history and
+consumer tests demonstrate another real compatibility contract, maintainers
+can add one narrow Neurocommand policy rule with its evidence and regression
+test. That decision does not add fields to the release manifest.
+
+For each policy-required alias, the requested
+one-payload/two-namespaces intent is implemented with a directory symbolic
+link, not a literal hard link. POSIX does not support directory hard links, and
+CVMFS emulates file hard-link groups only within one directory. A directory
+symlink also avoids duplicating catalog entries for the unpacked image.
 
 If the exact-head integration test finds an old client that cannot use the
 directory symlink, the safe fallback is a generated compatibility directory
 whose payload entries have the same CVMFS content hashes. CVMFS
 content-addressed storage avoids duplicate payload blobs, although the
-compatibility directory would add catalog entries. The linked PR must record
-which representation passed testing; it must not silently omit the old path.
+compatibility directory would add catalog entries. This fallback applies only
+to a policy-required alias. The linked PR must record which representation
+passed testing; it must not silently omit a required path.
+
+The compatibility namespace is deliberately one-way. Canonical resolution,
+platform selection, modules, inventories, and cleanup never discover a release
+by reading an alias. Only the CVMFS publisher and isolated legacy adapter
+consume the Neurocommand compatibility policy.
 
 ### Existing releases
 
@@ -277,9 +298,22 @@ catalogue and does not rewrite existing nested catalogs.
 
 That is a permanent supported condition, not an intermediate deployment state:
 
-- old release without schema v1 → legacy resolver;
+- historical release selected from the legacy catalogue → legacy resolver;
 - new release with valid schema v1 → manifest resolver;
-- old client accessing a new release → manifest-declared legacy CVMFS path.
+- old client accessing a compatible new default AMD64 release → policy-created
+  legacy alias; and
+- old client accessing a new-only platform or variant → not exposed through
+  the legacy view.
+
+The final case is intentional. A client that cannot represent platform or
+variant selection cannot safely be made compatible by inventing another
+underscore-encoded identity.
+
+The default flat alias preserves the existing AMD64 contract; it is not a
+cross-platform dispatcher. An ARM client must use the manifest-aware resolver.
+If exact-head testing finds Neurodesktop or another supported ARM client still
+constructing the flat path, that client must receive the conditional
+manifest-aware fix before ARM publication is enabled.
 
 ### Publication transaction
 
@@ -289,10 +323,11 @@ For one release, Neurocommand opens one CVMFS transaction and:
 2. writes the exact promoted `release.json`;
 3. preserves the current unpacked `.simg`, wrapper, command, and nested-catalog
    shape;
-4. creates the complete legacy directory alias;
+4. applies the isolated compatibility policy and creates any required aliases;
 5. generates or updates modules and compatibility metadata;
-6. verifies both full paths, a non-empty `commands.txt`, module resolution, and
-   an Apptainer/Singularity execution through each path; and
+6. verifies the canonical path and every policy-required alias, a non-empty
+   `commands.txt`, module resolution, and an Apptainer/Singularity execution
+   through each published path; and
 7. publishes only if every check passes.
 
 Failure aborts the transaction, leaving the previous CVMFS revision visible.
@@ -371,21 +406,24 @@ registry. Trusted promotion:
 
 1. verifies every required build-variant/platform candidate against its PR head
    SHA and recipe fingerprint;
-2. pushes and verifies the child image manifests and tested SIF artifacts, and
-   verifies the manifest-declared legacy object-store keys;
+2. pushes and verifies the child image manifests and tested SIF artifacts; the
+   isolated legacy publisher continues to verify any compatibility object keys
+   it creates;
 3. creates and verifies the complete image index;
 4. resolves post-push digests for every recorded registry;
 5. generates and validates the immutable release manifest;
 6. attaches the release manifest to the index and commits the same JSON to
    trusted release history;
-7. asks Neurocommand to publish the canonical and legacy CVMFS paths; and
+7. asks Neurocommand to publish the canonical CVMFS paths and apply its
+   compatibility policy; and
 8. after Neurocommand acknowledges that CVMFS revision, updates generated
    presentation views and floating tags.
 
 A failure before step 6 leaves only immutable registry objects. A failure in
 steps 6 or 7 leaves an immutable manifest in release history but no generated
-view selects it. A partial platform set or missing legacy CVMFS path is never
-represented as an available release.
+view selects it. A partial platform set, or a missing alias required by the
+Neurocommand compatibility policy, is never represented as an available
+release.
 
 Legacy object-store SIFs remain published and retained by this change. They are
 compatibility inputs and rollback assets, not the source of truth for new
@@ -412,17 +450,18 @@ release manifest in this proposal are different:
 The release manifest is immutable and contains no mutable lifecycle `status`.
 Committing it to trusted release history records a published distribution
 graph, but does not by itself make the release selectable. Selection occurs
-only after Neurocommand acknowledges the CVMFS revision containing both paths
-and promotion regenerates the presentation views. A future withdrawal can
-change those views or add a separate tombstone while retaining the historical
-manifest and digests; that mechanism is outside this proposal.
+only after Neurocommand acknowledges the CVMFS revision containing all
+canonical paths and any compatibility alias required by its local policy, then
+promotion regenerates the presentation views. A future withdrawal can change
+those views or add a separate tombstone while retaining the historical manifest
+and digests; that mechanism is outside this proposal.
 
 The identical release JSON is:
 
 - committed by the trusted Neurocontainers promotion workflow;
 - attached to the OCI image index;
 - copied into the canonical CVMFS release directory; and
-- consumed by Neurocommand to generate compatibility and presentation views.
+- consumed by Neurocommand to generate canonical views.
 
 Neurocommand vendors or fetches the schema with a recorded SHA-256. CI in both
 repositories must fail if their schema bytes or fixtures differ.
@@ -473,18 +512,12 @@ the final JSON Schema:
     "linux/amd64": {
       "cvmfs_variant": "amd64",
       "cvmfs_release_path": "containers/fsl/6.0.7.16_amd64_20260728",
-      "cvmfs_payload_path": "containers/fsl/6.0.7.16_amd64_20260728/fsl_6.0.7.16_20260728.simg",
-      "legacy_release_path": "containers/fsl_6.0.7.16_20260728",
-      "legacy_payload_path": "containers/fsl_6.0.7.16_20260728/fsl_6.0.7.16_20260728.simg",
-      "legacy_object_keys": ["fsl_6.0.7.16_20260728.simg"]
+      "cvmfs_payload_path": "containers/fsl/6.0.7.16_amd64_20260728/fsl_6.0.7.16_20260728.simg"
     },
     "linux/arm64": {
       "cvmfs_variant": "arm64",
       "cvmfs_release_path": "containers/fsl/6.0.7.16_arm64_20260728",
-      "cvmfs_payload_path": "containers/fsl/6.0.7.16_arm64_20260728/fsl_arm64_6.0.7.16_20260728.simg",
-      "legacy_release_path": "containers/fsl_arm64_6.0.7.16_20260728",
-      "legacy_payload_path": "containers/fsl_arm64_6.0.7.16_20260728/fsl_arm64_6.0.7.16_20260728.simg",
-      "legacy_object_keys": ["fsl_arm64_6.0.7.16_20260728.simg"]
+      "cvmfs_payload_path": "containers/fsl/6.0.7.16_arm64_20260728/fsl_6.0.7.16_20260728.simg"
     }
   },
   "deploy": {
@@ -517,6 +550,10 @@ Required identity, source, platform, digest, path, and deploy fields fail
 validation when absent. Unknown additive fields may be accepted within schema
 version 1, but they cannot change the meaning of an existing field.
 
+The schema deliberately has no legacy name, alias, or object-key fields.
+Backwards compatibility is a consumer-side deployment concern and must not
+become part of the OCI release identity or propagate into Neurocontainers.
+
 ## Resolution and generated views
 
 For a schema-v1 release, the shared Neurocommand resolver:
@@ -530,29 +567,72 @@ For a schema-v1 release, the shared Neurocommand resolver:
    complete reachable registry and verifies its subject and blob checksum; and
 6. reports the release ID, platform, path, and digests on failure.
 
-For a release without a valid schema-v1 manifest, Neurocommand uses the existing
-legacy resolver. This capability detection is automatic; there is no manually
-coordinated feature flag.
+Neurocommand uses the legacy resolver only for an identity selected from the
+historical catalogue, where no schema-v1 manifest is expected. A manifest-aware
+selection with a missing, malformed, or unsupported manifest fails closed; it
+must not downgrade into underscore parsing. Capability detection is automatic,
+but validation failure is not a feature flag.
 
 The same resolver library or CLI is used by launchers, local download,
 CVMFS preflight, full tests, and diagnostics. Shell entrypoints consume
 structured output rather than implementing separate registry and naming logic.
 
+### Legacy code boundary
+
+Backwards compatibility is an adapter, not a branch threaded through the new
+resolver:
+
+- canonical code reads `release_id`, `platforms`, and immutable digests and
+  does not import the legacy name parser;
+- one Neurocommand legacy adapter parses historical flat names and applies a
+  separately versioned compatibility policy;
+- the CVMFS publisher invokes that adapter only after canonical publication
+  inputs validate;
+- cleanup starts from canonical manifest inventory and adds policy aliases as
+  retained projections, never as release identities; and
+- a repository check prevents new underscore-name parsing or alias synthesis
+  outside the adapter.
+
+This boundary keeps the old interface supported without allowing it to define
+the platform model, new modules, or future variants.
+
+Neurocommand owns the checked-in policy, proposed as
+`compatibility/cvmfs-flat-v1.json`. Its schema-v1 rollout has exactly one rule:
+
+```text
+default variant + linux/amd64
+  -> containers/<name>_<software-version>_<build-date>
+```
+
+There is no generic “append platform or variant to the name” rule. Extending
+the policy requires evidence of an existing consumer contract, maintainer
+approval, and an exact regression fixture. The policy is not copied into
+Neurocontainers, OCI metadata, or the release manifest.
+
 ### Compatibility outputs
 
-For new releases, Neurocommand generates from the manifest:
+For schema-v1 releases, Neurocommand generates canonical outputs from the
+manifest:
 
-- `apps.json`;
-- `cvmfs/log.txt`;
 - the CVMFS publication inventory;
 - modulefiles and launchers; and
-- cleanup keep-list entries for both canonical and legacy identities.
+- cleanup keep-list entries for canonical identities.
 
-The formats consumed by old clients remain valid. `apps.json` and
-`cvmfs/log.txt` are generated views, not release authority, and are updated
-only after the CVMFS publication acknowledgement. In particular,
-`cvmfs/log.txt` continues to list the manifest's legacy concrete identity so
-existing scripts and cleanup jobs see the same name they understand.
+The compatibility adapter then projects only policy-covered releases into
+legacy formats:
+
+- `apps.json` entries intended for legacy consumers;
+- `cvmfs/log.txt`; and
+- policy-alias keep-list entries.
+
+Those formats may contain only releases they can represent. They list the alias
+returned by the adapter rather than applying their own naming logic and omit
+canonical-only ARM and named variants. Modern manifest-aware consumers can see
+all published platform entries.
+
+`apps.json` and `cvmfs/log.txt` are generated views, not release authority, and
+are updated only after the relevant CVMFS publication acknowledgement. Their
+compatibility subset cannot drive canonical inventory or cleanup.
 
 The public module roots and default user interface remain:
 
@@ -570,22 +650,23 @@ module load fsl/6.0.7.16-gpu
 ```
 
 If a concrete module name such as `fsl_gpu/6.0.7.16` was previously published,
-it remains as a compatibility alias. Module generation may call a
-CVMFS-hosted dispatcher to choose the manifest's platform path, but existing
-module names and roots do not disappear in this change.
+it remains available for its historical release. Schema-v1 releases do not
+synthesize that module alias. New module generation may call a CVMFS-hosted
+dispatcher to choose the manifest's platform path, but existing module names
+and roots do not disappear in this change.
 
 ### Cleanup boundary
 
-Before producer activation, the Neurocommand PR adds schema-v1 releases and
-their compatibility identities to the keep set. Existing cleanup may continue
-under its current policy, but the linked change must not make either namespace
-eligible for deletion and must not delete legacy OCI, object-store, or CVMFS
-content.
+Before producer activation, the Neurocommand PR makes canonical schema-v1
+inventory authoritative for new releases and adds policy aliases to the
+retained path set. Existing cleanup may continue under its current policy, but
+the linked change must not make a canonical release or policy alias eligible
+for deletion and must not delete legacy OCI, object-store, or CVMFS content.
 
 The exact-head cleanup dry run must prove that:
 
 - every release manifest is reachable independently of menu visibility;
-- canonical and legacy CVMFS paths are treated as one retained payload;
+- canonical paths and any policy aliases are treated as one retained payload;
 - every recorded child manifest and referrer is retained; and
 - existing releases without schema v1 remain in the legacy keep set.
 
@@ -616,15 +697,16 @@ Neurocommand owns:
 
 - schema validation and platform selection;
 - manifest-driven generated views;
-- canonical and legacy CVMFS publication in one transaction;
+- canonical CVMFS publication and compatibility-policy aliases in one
+  transaction;
 - modules, launchers, and local download resolution;
-- legacy parsing and fallback;
+- an isolated legacy parsing and compatibility adapter;
 - compatibility keep-list generation; and
 - failure diagnostics.
 
 The legacy right-hand parser and deployment safety checks in
-`neurodesk/neurocommand#767` remain useful. New schema-v1 paths are read from
-the manifest, not parsed.
+`neurodesk/neurocommand#767` remain useful but belong inside the adapter. New
+schema-v1 paths are read from the manifest, not parsed.
 
 ### Neurodesktop
 
@@ -634,12 +716,13 @@ Neurodesktop continues to consume:
 - the same public module roots;
 - the same module names;
 - the same local container root; and
-- valid legacy CVMFS paths.
+- existing and policy-required legacy CVMFS paths.
 
-Its current hard-coded container test should pass unchanged through the legacy
-alias. That is valuable compatibility evidence, not automatically a reason to
-change Neurodesktop. A source PR is opened only if the exact-head run exposes a
-real incompatibility.
+Its current hard-coded default-container test should pass unchanged through the
+policy-required default AMD64 alias. That is valuable compatibility evidence,
+not a reason to manufacture flat ARM or named-variant paths. ARM and variant
+support is tested through manifest-aware integration. A source PR is opened
+only if the exact-head run exposes a real incompatibility.
 
 ## One coordinated merge train
 
@@ -647,7 +730,7 @@ real incompatibility.
 
 | Order | Repository | Required contents | Activation behaviour |
 |---|---|---|---|
-| 1 | `neurodesk/neurocommand` | Schema consumer, resolver, manifest-generated compatibility outputs, canonical plus legacy CVMFS publication, module dispatch, keep-list hardening, and tests. | Dormant for releases without schema v1; legacy behaviour remains. |
+| 1 | `neurodesk/neurocommand` | Schema consumer, resolver, isolated legacy adapter and policy, canonical CVMFS publication with required policy aliases, module dispatch, keep-list hardening, and tests. | Dormant for releases without schema v1; legacy behaviour remains. |
 | 2 | `neurodesk/neurodesktop` | Only the smallest source change demonstrated necessary by exact-head testing. | Conditional; no PR is preferred when current source passes. |
 | 3 | `neurodesk/neurocontainers` | One integrated or superseding implementation of `neurodesk/neurocontainers#2913` and `neurodesk/neurocontainers#2914`: matrix candidates, complete promotion, schema, OCI graph, and immutable release history. | Merged last; the first trusted schema-v1 release activates the new path for that release. |
 
@@ -682,7 +765,7 @@ head commits. That run builds a release fixture containing:
 - `default` on AMD64 and ARM64 under one OCI index;
 - one named build variant such as `gpu`;
 - an immutable release manifest with exact registry and CVMFS paths; and
-- generated old and new Neurocommand views.
+- generated manifest-aware and legacy-compatible Neurocommand views.
 
 It then proves:
 
@@ -691,15 +774,25 @@ It then proves:
 - refusal to promote a missing or failed platform child;
 - native-referrers and fallback-tag publication;
 - exact SIF selection by recorded digest;
-- canonical and full legacy CVMFS paths execute the same content;
-- the unchanged Neurodesktop container test can use the legacy path;
+- the canonical default AMD64 path and its policy alias execute the same
+  content;
+- ARM64 and the named variant publish canonical paths without synthesized flat
+  aliases or legacy-log entries;
+- the unchanged Neurodesktop default-container test can use the policy alias;
 - modules work on AMD64 and ARM64 without changing their public name or root;
 - CVMFS-disabled and local/offline paths work;
-- a missing, incomplete, or unsupported manifest returns to legacy resolution;
+- historical catalogue entries still use legacy resolution;
+- a missing, malformed, or unsupported manifest for a schema-v1 selection
+  fails closed without invoking the legacy parser;
+- a manifest-aware ARM client never resolves the AMD64 flat alias;
 - registry failure uses only another complete, verified registry entry;
 - CVMFS failure aborts publication and leaves the previous revision visible;
-  and
-- cleanup dry-run retains existing, hidden, canonical, and legacy releases.
+- compatibility-alias failure aborts publication only when the policy requires
+  that alias;
+- cleanup dry-run retains existing, hidden, canonical, and policy-alias
+  releases; and
+- repository checks find no new legacy parsing or alias synthesis outside the
+  compatibility adapter.
 
 The manifest, resolved digests, generated-file diff, CVMFS path listing, test
 results, and tested SHAs are linked from each required PR. Testing branch names
@@ -713,19 +806,21 @@ ordered merge, not a multi-stage deployment:
 1. merge the backwards-compatible Neurocommand consumer;
 2. merge the Neurodesktop compatibility fix only if the proof required one;
 3. merge the integrated Neurocontainers producer; and
-4. promote one already-tested schema-v1 release and observe its OCI, CVMFS, old
-   path, new path, module, and Neurodesktop checks before closing the window.
+4. promote one already-tested schema-v1 release and observe its OCI, canonical
+   CVMFS path, policy-required compatibility alias, module, and Neurodesktop
+   checks before closing the window.
 
 GitHub, OCI registries, and CVMFS cannot share one distributed transaction.
 Safety comes from two per-release commit points:
 
 - trusted release history records only a complete OCI graph; and
-- one CVMFS transaction publishes the canonical and legacy paths together.
+- one CVMFS transaction publishes the canonical paths and any aliases required
+  by the compatibility policy together.
 
 Generated views select the release only after both commit points succeed. A new
 client can still use the recorded OCI SIF when CVMFS is temporarily unavailable
-after activation. An old client first sees the release only after its legacy
-CVMFS path is published.
+after activation. A legacy view exposes the release only if its policy alias
+has been published; it never synthesizes visibility for a new-only variant.
 
 ### Go/no-go checklist
 
@@ -733,6 +828,7 @@ The merge window proceeds only when:
 
 - [ ] maintainers approve the identity and legacy-path decisions in this
   document;
+- [ ] no platform or build variant automatically creates a compatibility alias;
 - [ ] the two required PRs link each other and pin the same schema and fixtures;
 - [ ] `neurodesk/neurocontainers#2913` and `neurodesk/neurocontainers#2914`
   have one agreed integration outcome;
@@ -749,7 +845,7 @@ The merge window proceeds only when:
 - [ ] maintainers for the affected repositories confirm the window.
 
 Failure of any item stops the merge train. It does not create another supported
-mode or justify bypassing compatibility.
+mode or justify bypassing the compatibility policy.
 
 ## Rollback
 
@@ -766,10 +862,12 @@ immutable content.
   `apps.json`, `cvmfs/log.txt`, module views, and floating-tag digests.
 - Abort an unpublished CVMFS transaction. If publication completed, restore the
   recorded previous CVMFS revision.
-- A new client automatically returns to legacy resolution when the schema-v1
-  release is no longer selected.
+- If a schema-v1 release is rolled back, clients return to the previously
+  selected release. They use legacy resolution only when that previous release
+  is a historical catalogue entry.
 - Existing clients continue using unchanged legacy releases and the retained
-  legacy paths of new releases.
+  aliases of compatible new releases. Canonical-only variants disappear from
+  manifest-aware views but do not require a fabricated legacy fallback.
 
 The immutable release manifest and candidate objects may remain for diagnosis;
 they are not selected and are not deleted during rollback.
@@ -781,14 +879,14 @@ scope.
 
 | Repository | Area | Required change |
 |---|---|---|
-| Neurocontainers | `builder/variants.py` and callers in `neurodesk/neurocontainers#2913` | Preserve logical name, build variant, platform, and legacy concrete identity as separate fields. |
+| Neurocontainers | `builder/variants.py` and callers in `neurodesk/neurocontainers#2913` | Preserve logical name, build variant, and platform as separate fields; do not turn candidate names into public aliases. |
 | Neurocontainers | candidate/promotion code in `neurodesk/neurocontainers#2914` | Matrix over all required candidates and bind every artifact to the tested PR head. |
 | Neurocontainers | release generation | Validate schema, retain build history, record post-push digests, and generate the OCI graph. |
-| Neurocommand | `fetch_and_run.sh`, `fetch_containers.sh`, transparent-singularity | Call one manifest resolver for schema-v1 releases and retain legacy fallback. |
-| Neurocommand | `sync_containers_to_cvmfs.sh` | Consume release manifests and publish canonical plus legacy paths atomically. |
-| Neurocommand | `reconcile_module_files.py` | Use explicit manifest identity for new releases and retain the legacy parser. |
-| Neurocommand | `write_log.py`, `build_menu.py`, `containers.sh` | Generate compatibility views without parsing presentation labels. |
-| Neurocommand | upload/cleanup and DOI workflows | Use manifest inventory and keep both identities; perform no activation-time deletion. |
+| Neurocommand | `fetch_and_run.sh`, `fetch_containers.sh`, transparent-singularity | Call one manifest resolver for schema-v1 releases; invoke the adapter only for historical selections. |
+| Neurocommand | `sync_containers_to_cvmfs.sh` | Consume release manifests and publish canonical paths plus any policy aliases atomically. |
+| Neurocommand | `reconcile_module_files.py` | Use explicit manifest identity for new releases and call the adapter for historical entries. |
+| Neurocommand | `write_log.py`, `build_menu.py`, `containers.sh` | Consume structured canonical or adapter output without owning naming parsers. |
+| Neurocommand | upload/cleanup and DOI workflows | Use canonical manifest inventory and retain policy alias projections; perform no activation-time deletion. |
 | Neurodesktop | `environment_variables.sh`, `test_neurodesktop.sh` | Expected to remain unchanged; use them as compatibility tests. |
 
 ## Alternatives considered
@@ -807,8 +905,8 @@ implementation in `neurodesk/neurocontainers#2913`. It is simple for legacy
 consumers, but makes ARM a different tool, creates separate OCI repositories,
 and conflicts with the same-tag multi-architecture direction accepted in
 [neurocontainers#2593](https://github.com/neurodesk/neurocontainers/issues/2593).
-This proposal retains those concrete names only as explicit compatibility
-identities.
+This proposal retains a concrete name only when it is an existing supported
+interface, and never manufactures one for a new variant.
 
 ### Put architecture in separate OCI tags
 
@@ -825,9 +923,9 @@ record one exact SIF per platform.
 ### Rename the unpacked payload to `rootfs`
 
 That name is clearer than a directory ending in `.simg`, but it would require
-another compatibility alias inside every release and changes more publisher,
-module, maintenance, and test code. Keeping the existing inner name is safer
-for this change.
+an additional inner alias for each policy-covered default release and changes
+more publisher, module, maintenance, and test code. Keeping a uniform logical
+`.simg` inner name is safer for this change.
 
 ### Change Neurodesktop at the same time
 
@@ -839,10 +937,14 @@ unchanged. A third PR is justified only by a demonstrated failure.
 
 The proposal intentionally accepts:
 
-- two CVMFS namespace entries for every new payload;
+- an additional CVMFS namespace entry only where the isolated compatibility
+  policy requires it;
 - a permanent legacy resolver for historical releases;
-- a schema and generated compatibility views that must be versioned and tested
-  across repositories;
+- legacy clients not seeing new-only platforms or variants they cannot
+  represent safely;
+- a manifest schema that must be versioned and tested across the two required
+  repositories;
+- a separately versioned Neurocommand compatibility policy and legacy views;
 - an OCI index even for single-platform releases;
 - rejection rather than overwrite for same-day conflicting builds; and
 - a larger coordinated implementation review in exchange for avoiding
@@ -852,6 +954,8 @@ It avoids:
 
 - moving existing containers;
 - duplicating unpacked payload data in the normal compatibility representation;
+- allowing legacy parsing to spread into canonical platform selection;
+- turning compatibility aliases into a second public naming scheme;
 - encoding platform into a logical tool name;
 - choosing artifacts by list order or floating tags;
 - using menu visibility as retention truth; and
@@ -869,13 +973,17 @@ Approval of this document means agreement that:
   concrete platform names as the target from
   `neurodesk/neurocommand#733`;
 - [ ] SIFs attach to platform child manifests;
-- [ ] every new canonical CVMFS release includes its full manifest-declared
-  legacy path in the same transaction;
+- [ ] the release manifest has no legacy fields, and one isolated
+  Neurocommand policy defines the compatibility aliases;
+- [ ] ARM and named variants receive no flat alias by default;
+- [ ] when the compatibility policy requires an alias, the canonical path and
+  alias publish in the same transaction;
 - [ ] the existing inner `.simg` layout, legacy module aliases, and public
   module roots remain;
 - [ ] existing releases are not backfilled or removed;
 - [ ] the immutable release manifest contains no mutable lifecycle status, and
-  generated views activate it only after CVMFS acknowledges both paths; and
+  generated views activate it only after CVMFS acknowledges its canonical
+  paths and any policy aliases; and
 - [ ] implementation uses two required linked PRs, with Neurodesktop conditional
   on a failing compatibility test.
 

--- a/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
+++ b/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
@@ -1,0 +1,1131 @@
+# Proposal: container identity, CVMFS layout, and OCI manifests
+
+> Status: draft for maintainer review<br>
+> Scope: `neurodesk/neurocontainers`, `neurodesk/neurocommand`, and
+> `neurodesk/neurodesktop`<br>
+> GitHub state reviewed: 2026-07-28
+
+## Summary
+
+This proposal replaces the flat CVMFS container namespace:
+
+```text
+/containers/<name>_<version>_<builddate>/
+```
+
+with an explicit release hierarchy:
+
+```text
+/containers/<name>/<version>_<variant>_<builddate>/
+```
+
+It also makes a generated release manifest, rather than a parsed filename or an
+`apps.json` display key, the contract between container building, OCI
+publication, CVMFS publication, module generation, local downloads, and
+Neurodesktop.
+
+The proposed OCI representation is:
+
+- one OCI repository per logical tool, such as `quay.io/neurodesk/fsl`;
+- one immutable tag per software version, product flavour, and build date;
+- an OCI image index at that tag, with one child manifest per supported
+  platform;
+- one SIF artifact attached to each platform-specific child manifest through
+  OCI 1.1 referrers; and
+- one Neurodesk release-manifest artifact attached to the top-level image
+  index.
+
+The important distinction is that a Neurodesk product **flavour** such as
+`default`, `gpu`, `cuda12`, or `mpi` is not an OCI platform variant.
+Architecture selection belongs in the OCI image index. Product flavour remains
+an explicit release dimension and, where necessary, an OCI tag dimension.
+
+The recommended rollout is additive. New and legacy paths and tags should be
+published together until Neurocommand, Neurodesktop, external HPC module users,
+and maintenance jobs have moved to the manifest-backed resolver. No existing
+container should be moved or deleted as the first step.
+
+## Proposed decisions
+
+1. Define a release as the tuple:
+
+   ```text
+   (name, software_version, flavour, platform, build_date)
+   ```
+
+2. Derive a concrete CVMFS `variant` identifier from `flavour` and `platform`:
+
+   | Flavour | OCI platform | CVMFS variant |
+   |---|---|---|
+   | `default` | `linux/amd64` | `amd64` |
+   | `default` | `linux/arm64` | `arm64` |
+   | `gpu` | `linux/amd64` | `gpu-amd64` |
+   | `gpu` | `linux/arm64` | `gpu-arm64` |
+   | `cuda12` | `linux/amd64` | `cuda12-amd64` |
+
+3. Keep the logical tool name stable across platforms. For example, ARM FSL is
+   represented as `name=fsl`, `platform=linux/arm64`, rather than requiring
+   `name=fsl_arm64`.
+
+4. Never infer release fields by splitting an application display name, OCI
+   repository, or CVMFS path. Those strings are projections of explicit
+   metadata.
+
+5. Use an OCI image index for architecture selection. Do not use OCI
+   `platform.variant` for Neurodesk concepts such as `gpu`; OCI defines that
+   field for CPU variants such as ARM `v8` or x86-64 `v2`.
+
+6. Attach each SIF to the platform-specific child manifest, not only to the
+   top-level multi-platform index. A SIF is architecture-specific and should
+   have one unambiguous subject.
+
+7. Treat immutable tags and digests as release identities. Floating tags are
+   convenience pointers only and must never be recorded as the reproducibility
+   reference.
+
+8. Generate `apps.json`, CVMFS inventory, modulefiles, cleanup keep-lists, and
+   application lists from release manifests. `cvmfs/log.txt` can remain as a
+   compatibility output during migration, but not as the source of truth.
+
+## Motivation
+
+### The current filename is carrying too many meanings
+
+Current code commonly assumes that a container is exactly:
+
+```text
+<name>_<version>_<YYYYMMDD>
+```
+
+This assumption appears in:
+
+- [`neurodesk/fetch_containers.sh`](neurodesk/fetch_containers.sh);
+- [`neurodesk/fetch_and_run.sh`](neurodesk/fetch_and_run.sh);
+- [`neurodesk/transparent-singularity/run_transparent_singularity.sh`](neurodesk/transparent-singularity/run_transparent_singularity.sh);
+- [`cvmfs/reconcile_module_files.py`](cvmfs/reconcile_module_files.py);
+- [`cvmfs/sync_containers_to_cvmfs.sh`](cvmfs/sync_containers_to_cvmfs.sh);
+- [`containers.sh`](containers.sh);
+- [`.github/workflows/upload_containers_simg.sh`](.github/workflows/upload_containers_simg.sh);
+- DOI and stale-object maintenance workflows; and
+- `neurodesktop/config/test_neurodesktop.sh` in the Neurodesktop repository.
+
+That works for the 365 current entries in `cvmfs/log.txt`, all of which have
+exactly two underscores. It does not provide a durable grammar for names,
+versions, product flavours, and architectures that may themselves contain
+delimiters.
+
+Draft Neurocommand PR
+[#767](https://github.com/neurodesk/neurocommand/pull/767) correctly makes the
+legacy parser work from the right, allowing concrete names such as
+`fsl_gpu_arm64`. That is a useful compatibility fix, but continuing to improve
+filename parsing would leave the filename as an undocumented database schema.
+
+### Variant and multi-architecture work is already active
+
+The relevant work is not hypothetical:
+
+- Neurocontainers issue
+  [#1092](https://github.com/neurodesk/neurocontainers/issues/1092) requests
+  first-class container variations.
+- Neurocommand issue
+  [#733](https://github.com/neurodesk/neurocommand/issues/733) tracks ARM
+  publication and contains maintainer direction to make variation a general
+  builder feature.
+- Draft Neurocontainers PR
+  [#2913](https://github.com/neurodesk/neurocontainers/pull/2913) implements
+  variant fan-out for default, ARM, GPU, CUDA, and combined variants.
+- Draft Neurocommand PR
+  [#767](https://github.com/neurodesk/neurocommand/pull/767) adapts deployment,
+  module reconciliation, menu generation, and cleanup to those concrete names.
+- Neurocontainers issue
+  [#2593](https://github.com/neurodesk/neurocontainers/issues/2593) records
+  agreement to publish multi-architecture artifacts under the same OCI tags and
+  let clients select the appropriate object.
+
+The builder fan-out in PR #2913 should be preserved. This proposal changes how
+the resulting axes are represented at the distribution boundary: base name,
+flavour, and platform remain separate fields instead of being recoverable only
+from a concatenated concrete name.
+
+### Release metadata already needs to become authoritative
+
+Neurocontainers issue
+[#2796](https://github.com/neurodesk/neurocontainers/issues/2796) asks full
+tests to resolve an artifact from release metadata instead of hard-coded SIF
+wildcards. Neurocommand issue #733 documents how ARM artifacts that existed in
+release metadata were omitted from `apps.json` and then deleted by cleanup
+because cleanup used the UI publication view as its keep-list.
+
+Draft Neurocontainers PR
+[#2914](https://github.com/neurodesk/neurocontainers/pull/2914) is a strong
+foundation: it binds a tested Docker archive, SIF, checksum, recipe fingerprint,
+commit, PR, and generated release JSON into a promotion manifest. The layout
+work should extend that manifest to cover every flavour and platform, rather
+than introduce a second metadata path.
+
+### CVMFS is naturally hierarchical
+
+CVMFS recommends nested catalogs at software release boundaries because
+releases are normally immutable and clients generally use only one release at a
+time. The new `<name>/<release>` hierarchy gives us a stable place for that
+boundary and avoids putting every release directly in the large
+`/containers` directory.
+
+## Terminology and identity rules
+
+### Logical name
+
+`name` is the stable recipe/tool identity, for example `fsl`, `dcm2niix`, or
+`deepretinotopy`.
+
+- It is the Neurocontainers recipe directory name.
+- It is the OCI repository name.
+- It is the first directory beneath CVMFS `/containers`.
+- It does not include architecture.
+- It does not include the default product flavour.
+
+### Software version
+
+`software_version` is the upstream tool version, not the container build date.
+The existing release JSON field named `version` inside an app currently stores
+the build date, so the new schema must use unambiguous names during migration:
+
+```json
+{
+  "software_version": "6.0.7.16",
+  "build_date": "20260728"
+}
+```
+
+For the proposed underscore-delimited CVMFS release directory, new software
+versions should be restricted to:
+
+```text
+[A-Za-z0-9][A-Za-z0-9.+-]*
+```
+
+In particular, `_` and `/` are not permitted in a newly published version.
+Existing versions should be audited before enforcing this. Code must still use
+manifest fields rather than parse the release directory.
+
+### Flavour
+
+`flavour` describes a Neurodesk product/build choice such as:
+
+```text
+default
+gpu
+cuda12
+mpi
+openrecon
+```
+
+It is independent of CPU architecture. A recipe may constrain a flavour to a
+set of supported platforms.
+
+Flavour identifiers should match:
+
+```text
+[a-z0-9][a-z0-9.-]*
+```
+
+This deliberately excludes `_`, keeping the CVMFS release directory
+human-readable and delimiter-safe.
+
+### Platform
+
+`platform` uses OCI terminology:
+
+```text
+linux/amd64
+linux/arm64
+```
+
+Recipe aliases such as `x86_64` and `aarch64` can remain accepted at input, but
+release metadata should normalize them to OCI values. If a genuine CPU variant
+is required, it is recorded separately, for example:
+
+```json
+{
+  "os": "linux",
+  "architecture": "arm64",
+  "variant": "v8"
+}
+```
+
+### CVMFS variant
+
+The `variant` in the requested CVMFS path is a concrete, filesystem-safe
+projection of flavour and platform:
+
+```text
+default + amd64 -> amd64
+default + arm64 -> arm64
+gpu     + amd64 -> gpu-amd64
+gpu     + arm64 -> gpu-arm64
+```
+
+This projection is generated and stored in the release manifest as
+`cvmfs_variant`; clients do not reconstruct it.
+
+### Build date and immutability
+
+`build_date` remains an eight-digit UTC date:
+
+```text
+YYYYMMDD
+```
+
+An immutable tag or CVMFS release directory must not be overwritten with
+different content. Promotion must fail if the same
+`(name, version, flavour, build_date)` already exists with another digest.
+
+This implies at most one distinct release of a name/version/flavour on a UTC
+date. If same-day rebuilds are required, maintainers should approve an extended
+build identifier such as `YYYYMMDD.2` before implementation. A source commit and
+content digests remain mandatory even when the date is unique.
+
+## Proposed CVMFS layout
+
+Example:
+
+```text
+/cvmfs/neurodesk.ardc.edu.au/
+├── containers/
+│   ├── fsl/
+│   │   ├── 6.0.7.16_amd64_20260728/
+│   │   │   ├── .cvmfscatalog
+│   │   │   ├── release.json
+│   │   │   ├── commands.txt
+│   │   │   ├── bin/
+│   │   │   └── rootfs/
+│   │   ├── 6.0.7.16_arm64_20260728/
+│   │   │   └── ...
+│   │   └── 6.0.7.16_gpu-amd64_20260728/
+│   │       └── ...
+│   ├── dcm2niix/
+│   │   └── v1.0.20240202_arm64_20260728/
+│   │       └── ...
+│   └── modules/
+└── neurodesk-modules/
+```
+
+Each release directory is immutable after a successful publish.
+
+### Release directory contents
+
+`release.json`
+: A byte-for-byte copy of the generated release manifest. It allows inspection
+  without consulting GitHub or an OCI registry.
+
+`rootfs/`
+: The unpacked SIF/sandbox tree served lazily by CVMFS. The current layout uses
+  a directory ending in `.simg`, which looks like a file but is an unpacked
+  directory. `rootfs` makes the on-disk representation explicit.
+
+`commands.txt`
+: The validated command inventory generated from the recipe deploy contract.
+  Publication fails if it is missing or empty.
+
+`bin/`
+: Generated transparent wrappers. Modulefiles prepend this directory, rather
+  than relying on every file in the release root being executable.
+
+Additional generated files such as environment metadata may remain in the
+release root, but every field used to regenerate them must be present in
+`release.json`.
+
+### Catalog boundaries
+
+Every release directory should be a nested catalog root. Prefer a repository
+policy such as a `.cvmfsdirtab` rule for `/containers/*/*` over ad hoc marker
+creation. That rule must explicitly exclude `/containers/modules/*` and any
+compatibility-alias subtree so they are not accidentally treated as release
+catalogs.
+
+The current publisher also creates nested catalogs inside the unpacked image at
+`usr`, `usr/lib`, and `usr/share`. Those deeper boundaries should initially be
+preserved for compatibility, then retained or removed based on
+`cvmfs_server list-catalogs -e` measurements. A release catalog should generally
+contain more than 1,000 and fewer than roughly 200,000 entries; very large
+rootfs trees may still need internal catalogs.
+
+### What CVMFS retains
+
+Following the direction in Neurocontainers issue #2593:
+
+- CVMFS stores the current active release snapshot needed for normal execution.
+- Git and OCI retain the full release-manifest history.
+- OCI and archival object storage retain old immutable SIFs by digest.
+- Withdrawal disables the active wrappers/module pointer before payload
+  removal.
+- Reproducibility instructions resolve an old manifest to an OCI digest even
+  after that release is no longer materialized in CVMFS.
+
+An artifact is never deleted merely because it is hidden from a menu or absent
+from `apps.json`.
+
+## Proposed OCI layout
+
+### Repositories and tags
+
+Use one repository per logical name:
+
+```text
+quay.io/neurodesk/<name>
+ghcr.io/neurodesk/<name>
+```
+
+Immutable default-flavour tag:
+
+```text
+<software_version>_<build_date>
+```
+
+Immutable named-flavour tag:
+
+```text
+<software_version>_<flavour>_<build_date>
+```
+
+Examples:
+
+```text
+quay.io/neurodesk/fsl:6.0.7.16_20260728
+quay.io/neurodesk/fsl:6.0.7.16_gpu_20260728
+```
+
+These preserve the v2 direction in Neurocontainers issue
+[#2408](https://github.com/neurodesk/neurocontainers/issues/2408), while adding
+an explicit product-flavour dimension.
+
+After all immutable objects and metadata have been verified, promotion may
+advance these convenience tags:
+
+```text
+<software_version>
+<software_version>_<flavour>
+latest
+```
+
+`latest` refers only to the default flavour. A flavour-specific `latest` tag
+should not be added until there is a concrete client requirement and an agreed
+naming rule.
+
+### Image index
+
+The immutable tag resolves to an OCI image index:
+
+```text
+fsl:6.0.7.16_20260728
+  ├── linux/amd64 -> image manifest sha256:...
+  └── linux/arm64 -> image manifest sha256:...
+```
+
+The index contains standard platform descriptors. Architecture must not also be
+encoded into the OCI repository name or immutable tag.
+
+A named product flavour gets another index:
+
+```text
+fsl:6.0.7.16_gpu_20260728
+  └── linux/amd64 -> image manifest sha256:...
+```
+
+If a flavour later supports ARM, an ARM child can be added only while the
+release is still a candidate. An immutable published index must never be
+mutated; a changed platform set requires a new build date.
+
+### SIF artifacts
+
+Attach a SIF to each child image manifest with:
+
+```text
+artifactType: application/vnd.sylabs.sif.layer.v1.sif
+subject:       <platform-specific image-manifest digest>
+```
+
+Recommended descriptor/manifest annotations include:
+
+```text
+org.opencontainers.image.title
+org.opencontainers.image.version
+org.opencontainers.image.created
+org.neurodesk.name
+org.neurodesk.software-version
+org.neurodesk.flavour
+org.neurodesk.platform
+org.neurodesk.build-date
+org.neurodesk.sif.sha256
+```
+
+The labels proposed in Neurocontainers issue
+[#2409](https://github.com/neurodesk/neurocontainers/issues/2409) remain
+applicable to the runnable image manifests. Equivalent annotations should be
+placed on the index and SIF artifact where useful.
+
+The resolver must:
+
+1. resolve an immutable tag to the top-level index digest;
+2. select the exact child descriptor for the host/requested platform;
+3. query referrers for that child digest;
+4. filter by the SIF artifact type;
+5. verify each returned manifest's subject, platform annotations, and expected
+   checksum;
+6. reject zero or multiple matching SIFs unless the release manifest identifies
+   one exact digest; and
+7. pull the SIF by digest, never by a floating tag.
+
+The current transparent-singularity implementation takes the first matching
+referrer. That is sufficient as an initial v2 experiment but is not a durable
+selection rule.
+
+### Registry compatibility
+
+OCI Distribution 1.1 defines the native
+`/v2/<name>/referrers/<digest>` endpoint and requires clients to fall back to
+the referrers tag schema when that endpoint returns `404`.
+
+Quay currently exposes a native referrers endpoint. The current Neurocommand
+code uses native referrers for Quay and the tag-schema fallback for GHCR. The
+shared resolver should implement the OCI fallback once rather than maintain
+registry-specific `curl` pipelines in shell.
+
+Neurocontainers issue #2408 describes Quay as primary and GHCR as a mirror,
+whereas PR #2914 currently treats GHCR as release-critical and Quay as
+best-effort. Until maintainers ratify one policy, the release manifest should
+record an ordered registry list with a separate index, child, and SIF digest for
+each registry. Clients must not assume different registries preserve identical
+manifest digests.
+
+## Release manifest
+
+### Storage
+
+Replace the current one-file-per-version history:
+
+```text
+releases/<name>/<version>.json
+```
+
+with:
+
+```text
+releases/<name>/<software_version>/<flavour>/<build_date>.json
+```
+
+For example:
+
+```text
+releases/fsl/6.0.7.16/default/20260728.json
+releases/fsl/6.0.7.16/gpu/20260728.json
+```
+
+This retains rebuild history instead of replacing the previous metadata for a
+software version. A generated `latest.json` may exist as a compatibility view,
+but it must contain or resolve to an immutable release ID.
+
+The same canonical JSON is:
+
+- committed by the trusted Neurocontainers promotion workflow;
+- attached as
+  `application/vnd.neurodesk.container-release.v1+json` to the top-level OCI
+  index;
+- copied to the CVMFS release directory; and
+- consumed when generating Neurocommand views.
+
+### Illustrative schema
+
+This is a discussion schema, not a final JSON Schema:
+
+```json
+{
+  "schema_version": 1,
+  "release_id": "fsl/6.0.7.16/default/20260728",
+  "name": "fsl",
+  "software_version": "6.0.7.16",
+  "flavour": "default",
+  "build_date": "20260728",
+  "status": "published",
+  "source": {
+    "repository": "neurodesk/neurocontainers",
+    "recipe": "recipes/fsl",
+    "git_commit": "0123456789abcdef",
+    "recipe_fingerprint": "sha256:..."
+  },
+  "oci": {
+    "immutable_tag": "6.0.7.16_20260728",
+    "registries": [
+      {
+        "repository": "quay.io/neurodesk/fsl",
+        "index_digest": "sha256:...",
+        "platforms": {
+          "linux/amd64": {
+            "manifest_digest": "sha256:...",
+            "sif_manifest_digest": "sha256:...",
+            "sif_blob_digest": "sha256:...",
+            "sif_sha256": "..."
+          },
+          "linux/arm64": {
+            "manifest_digest": "sha256:...",
+            "sif_manifest_digest": "sha256:...",
+            "sif_blob_digest": "sha256:...",
+            "sif_sha256": "..."
+          }
+        }
+      }
+    ]
+  },
+  "cvmfs": {
+    "repository": "neurodesk.ardc.edu.au",
+    "platforms": {
+      "linux/amd64": {
+        "variant": "amd64",
+        "path": "containers/fsl/6.0.7.16_amd64_20260728"
+      },
+      "linux/arm64": {
+        "variant": "arm64",
+        "path": "containers/fsl/6.0.7.16_arm64_20260728"
+      }
+    }
+  },
+  "deploy": {
+    "bins": ["fslmaths"],
+    "paths": ["/opt/fsl/bin"],
+    "apptainer_args": []
+  },
+  "apps": [
+    {
+      "id": "fsl",
+      "label": "FSL 6.0.7.16",
+      "exec": "",
+      "terminal": true
+    },
+    {
+      "id": "fsleyes",
+      "label": "FSLeyes 6.0.7.16",
+      "exec": "fsleyes",
+      "terminal": false
+    }
+  ],
+  "categories": [
+    "functional imaging",
+    "structural imaging"
+  ]
+}
+```
+
+The final schema should have a checked-in JSON Schema, a schema version, and
+validation in both repositories. Unknown additive fields should be tolerated
+within a schema version; missing identity, digest, platform, or deploy fields
+should fail publication.
+
+## Resolution flow
+
+```mermaid
+flowchart LR
+    A[Recipe + variant declaration] --> B[Tested per-platform candidates]
+    B --> C[Trusted promotion]
+    C --> D[Canonical release manifest]
+    D --> E[OCI image index]
+    D --> F[Platform SIF referrers]
+    D --> G[CVMFS release directories]
+    D --> H[apps.json and module views]
+    H --> I[Neurocommand / Neurodesktop resolver]
+    I -->|matching CVMFS path exists| G
+    I -->|CVMFS unavailable| E
+    E --> F
+```
+
+At runtime:
+
+1. A launcher identifies an app by a stable app ID and release ID, not by
+   splitting its label.
+2. The resolver determines the requested flavour and normalizes the host
+   platform.
+3. It selects the platform entry from the release manifest.
+4. If the recorded CVMFS release and `rootfs` exist, it executes that release.
+5. Otherwise it resolves the recorded OCI index and child digest, discovers the
+   exact SIF referrer, verifies it, and pulls it to local storage.
+6. Object-storage URLs and legacy OCI layouts remain last-resort migration
+   fallbacks only.
+
+This same resolver should be used by:
+
+- `fetch_and_run.sh`;
+- `fetch_containers.sh`;
+- transparent-singularity installation;
+- fulltest artifact selection;
+- CVMFS publication preflight;
+- stale-object cleanup; and
+- diagnostic tooling.
+
+The implementation can be a small Python CLI/library shipped by Neurocommand.
+Shell entrypoints should call it and consume structured JSON output. Repeating
+OCI token, manifest, referrer, and filename parsing in multiple shell scripts
+would recreate the current coupling.
+
+## Repository responsibilities
+
+### `neurodesk/neurocontainers`
+
+Neurocontainers owns the declared and built identity:
+
+- recipe schema for product flavours and supported platforms;
+- normalization of architecture aliases;
+- per-flavour/per-platform candidate fan-out;
+- coordinated testing of every index child;
+- generation and validation of the release manifest;
+- immutable OCI image publication;
+- multi-platform index creation;
+- per-platform SIF attachment;
+- provenance, checksum, and optional signature/attestation creation;
+- release-history storage; and
+- generated application metadata.
+
+PR #2913 supplies much of the fan-out logic. It should be adapted so that
+`name`, `flavour`, and `platform` survive as separate fields through the
+builder, rather than only producing names such as `fsl_gpu_arm64`.
+
+PR #2914 supplies the secure candidate-to-promotion boundary. It needs to:
+
+- matrix over concrete flavour/platform candidates;
+- include those fields in its candidate manifest and verification;
+- promote all required children as one coordinated release;
+- create the image index only after all required children pass;
+- attach the tested SIF to each child digest;
+- record post-push digests in the canonical release manifest; and
+- update floating tags only after the immutable graph is complete.
+
+The two draft PRs overlap heavily and should be rebased or integrated before
+implementation of this proposal. Merging both unchanged would leave the one-PR
+flow x86-only and the variant flow on the older release path.
+
+### `neurodesk/neurocommand`
+
+Neurocommand owns materialization and client resolution:
+
+- validate/import Neurocontainers release manifests;
+- generate `apps.json` without encoding identity in display keys;
+- generate the compatibility `cvmfs/log.txt` while it is still required;
+- publish the new CVMFS hierarchy;
+- generate modules and wrappers from manifest fields;
+- resolve local, CVMFS, and OCI locations;
+- select host platform and requested flavour;
+- verify OCI subjects and SIF digests;
+- retain legacy local/object-store fallbacks during migration;
+- drive cleanup from release state and retention policy; and
+- report actionable diagnostics.
+
+PR #767 remains valuable as a legacy parser and safety improvement. Its
+right-hand parsing should be retained for old flat identities, but new paths
+must use manifest fields directly.
+
+### `neurodesk/neurodesktop`
+
+Neurodesktop remains a consumer:
+
+- install the manifest-backed Neurocommand resolver;
+- keep CVMFS mounting and regional endpoint selection;
+- configure the module path exposed by the new module view;
+- use the resolver in container integration tests instead of constructing a
+  flat CVMFS path; and
+- keep local/offline containers compatible with the same release-directory
+  shape.
+
+No change to the CVMFS repository mount point is proposed:
+
+```text
+/cvmfs/neurodesk.ardc.edu.au
+```
+
+The changes are below its `containers` directory and in the generated module
+contents.
+
+## Known code impact
+
+This is the minimum inventory identified during review.
+
+| Repository | Area | Current assumption to remove or bridge |
+|---|---|---|
+| neurocommand | `neurodesk/write_log.py` | App display name plus build date produces the image ID. |
+| neurocommand | `neurodesk/build_menu.py` | Display-name parsing derives container and version arguments. |
+| neurocommand | `neurodesk/fetch_and_run.sh` | Resolves only a build date and constructs a module name. |
+| neurocommand | `neurodesk/fetch_containers.sh` | Constructs `IMG_NAME=name_version_date`. |
+| neurocommand | `transparent-singularity/run_transparent_singularity.sh` | Parses identity from underscores and contains registry-specific referrer logic. |
+| neurocommand | `cvmfs/sync_containers_to_cvmfs.sh` | Iterates `log.txt`, creates a flat release directory, and preflights only a legacy object key. |
+| neurocommand | `cvmfs/reconcile_module_files.py` | Parses image strings and rewrites paths with a flat-name regex. |
+| neurocommand | `containers.sh` | Splits every log line into name/version/date columns. |
+| neurocommand | `maintenance/fix_missing_bindpath-directories-on-cvmfs.sh` | Globs `/containers/*/*.simg`. |
+| neurocommand | upload/cleanup workflows | Derive legacy object names by underscore fields and use `apps.json`/`log.txt` as retention truth. |
+| neurocommand | DOI workflow | Derives the recipe name from the first underscore-delimited field. |
+| neurodesktop | `config/jupyter/environment_variables.sh` | Hard-codes current local and CVMFS module directories. |
+| neurodesktop | `config/test_neurodesktop.sh` | Constructs `/containers/package_version_date/package_version_date.simg`. |
+| neurodesktop | Dockerfile/startup | Wires local container storage to Neurocommand's current `containers` directory. |
+| neurocontainers | `builder/release.py` | Generates legacy ARM-specific app/image names. |
+| neurocontainers | `tools/generate_apps_json.py` | Merges one mutable release file per version and currently skips legacy ARM releases. |
+| neurocontainers | build/release workflows | Publish individual images before a coordinated multi-platform release graph exists. |
+| neurocontainers | fulltest tooling | Historically resolves dated SIF filenames rather than a manifest platform entry. |
+
+Tests containing literal flat paths must be updated or retained as explicit
+legacy-compatibility tests, not mechanically replaced.
+
+## Modules and application UX
+
+The CVMFS storage identity and user-facing module identity should be separate.
+
+Recommended module behaviour:
+
+```text
+module load fsl/6.0.7.16
+```
+
+selects the default flavour for the host platform.
+
+An explicit flavour may be exposed as:
+
+```text
+module load fsl/6.0.7.16-gpu
+```
+
+The modulefile should not point permanently at an AMD64 path in a repository
+also mounted on ARM. It can call a small resolver-generated dispatcher, or
+module generation can emit platform-specific logic using a normalized
+environment value set by Neurocommand/Neurodesktop.
+
+This work should also address the broader concerns in Neurocommand issue
+[#152](https://github.com/neurodesk/neurocommand/issues/152):
+
+- do not hard-code the CVMFS mount location into generated module content;
+- allow Apptainer or Singularity runtime selection;
+- keep generated module sources reviewable in Git;
+- make runtime flags configurable; and
+- leave room for meta-modules.
+
+An application label such as `FSLeyes 6.0.7.16` remains presentation only.
+Generated launchers receive explicit `release_id`, `app_id`, and optional
+`flavour`; quoting is mandatory.
+
+## Cleanup, withdrawal, and reproducibility
+
+Release status should be explicit:
+
+```text
+candidate -> published -> active -> deprecated -> withdrawn
+```
+
+- `published` means the immutable OCI graph and canonical manifest exist.
+- `active` means normal apps/modules may select it and CVMFS should materialize
+  it.
+- `deprecated` remains runnable but is not the preferred floating target.
+- `withdrawn` removes normal launchers/module pointers and records the reason.
+
+Cleanup computes reachability from all non-purged release manifests, not from
+the subset visible in `apps.json`.
+
+Before deletion it must account for:
+
+- every configured registry copy;
+- OCI child manifests and their referrers;
+- object-store SIFs;
+- the CVMFS materialized path;
+- floating tags;
+- release manifests;
+- an explicit retention interval; and
+- withdrawal/reproducibility policy.
+
+Dry-run output and tests are required. A UI visibility change must never make a
+release eligible for deletion.
+
+For withdrawn CVMFS content, update modules/wrappers and publish that revision
+before removing `rootfs`. Old release metadata must retain an exact OCI digest
+and explain how to reproduce the pull. This preserves the intent of the current
+stale-container wrapper while avoiding reconstruction of a legacy Docker
+reference from a filename.
+
+## Security and integrity
+
+- Resolve tags once, then pin and record digests.
+- Verify the platform child belongs to the expected index.
+- Verify a SIF artifact manifest refers to the selected child digest.
+- Verify artifact type, Neurodesk identity annotations, blob digest, and SIF
+  SHA-256 before execution or CVMFS publication.
+- Do not select `.manifests[0]` without comparison to the canonical release
+  manifest.
+- Preserve the candidate checks, recipe fingerprint, PR number, head commit,
+  Docker checksum, and SIF checksum introduced by PR #2914.
+- Make index assembly an atomic promotion gate: no release manifest or floating
+  tag is published until all required children pass.
+- Record per-registry digests and verify copies after mirroring.
+- Run `cvmfs_server check -s <release-path>` for pilots and regularly run the
+  repository integrity checker.
+
+Container signing and attestations from Neurocontainers issue
+[#504](https://github.com/neurodesk/neurocontainers/issues/504) can be added to
+the same OCI subject graph without another naming scheme. The manifest schema
+should reserve typed referrer entries for signatures, SBOMs, provenance, and
+security scan results.
+
+## Migration plan
+
+### Phase 0: ratify the contract
+
+- Decide the open questions at the end of this document.
+- Check in a versioned release JSON Schema.
+- Audit current recipe names and versions against the proposed character rules.
+- Decide how PRs #2913 and #2914 will be integrated.
+- Freeze new one-off filename parsers while the resolver is implemented.
+
+Exit criterion: maintainers approve the identity tuple, CVMFS variant rule, OCI
+tag rule, referrer subject rule, and registry priority.
+
+### Phase 1: generate manifests without changing publication
+
+- Extend the one-PR candidate manifest with flavour and platform.
+- Preserve release history by build date.
+- Generate the proposed canonical manifest alongside current release JSON.
+- Validate equivalence between the manifest and legacy image/SIF names.
+- Generate `apps.json`, `log.txt`, and cleanup keep-lists from the new manifest
+  in check-only mode.
+
+Exit criterion: generated legacy outputs are byte-equivalent or have reviewed
+diffs for a representative set of default, GUI, ARM, and hidden releases.
+
+### Phase 2: publish the OCI graph
+
+- Build and test all required platform children for a flavour.
+- Push immutable child manifests.
+- Create and verify the OCI image index.
+- Attach each tested SIF to its child manifest.
+- Attach the canonical release manifest to the index.
+- Copy and verify the full subject graph in each supported registry.
+- Advance floating tags last.
+
+Exit criterion: a standalone resolver can select and pull exact AMD64 and ARM64
+SIFs by manifest on both the primary registry and its fallback.
+
+### Phase 3: dual-publish CVMFS
+
+- Materialize the new `/containers/<name>/<release>` tree.
+- Keep the old flat tree during the pilot.
+- Generate both old and new module views.
+- Add per-release nested catalogs and inspect their entry counts.
+- Make publication idempotent and abort cleanly on a failed verification.
+
+To avoid duplicating rootfs catalog entries, test a compatibility alias such as:
+
+```text
+/containers/fsl_6.0.7.16_20260728
+  -> /containers/fsl/6.0.7.16_amd64_20260728
+```
+
+The target release may temporarily include the expected legacy inner name as a
+symlink to `rootfs`. Do not replace an existing materialized legacy catalog with
+this alias until Apptainer, CVMFS, module, and old-client tests pass. CVMFS
+content hashing reduces duplicate blob storage during a short dual-materialized
+period, but duplicate catalog entries still have a cost.
+
+Exit criterion: legacy and new clients run the same pilot digest from the same
+CVMFS revision.
+
+### Phase 4: migrate consumers
+
+- Move `fetch_and_run.sh`, `fetch_containers.sh`, and menu wrappers to release
+  IDs.
+- Move module reconciliation to manifest fields.
+- Move Neurodesktop integration tests to the resolver.
+- Move fulltests and CVMFS preflight to the shared resolver.
+- Move cleanup and DOI jobs to canonical identity fields.
+- Change diagnostics to print release ID, platform, CVMFS path, OCI subject, and
+  SIF digest.
+
+Exit criterion: repository searches find flat-name construction only in the
+legacy compatibility layer and its tests.
+
+### Phase 5: pilot and cut over
+
+Suggested pilots:
+
+1. `dcm2niix` or `niimath` for a small default multi-architecture release.
+2. A GUI-bearing container to validate menu generation.
+3. A GPU flavour after the two-platform default path is stable.
+
+For each pilot test:
+
+- AMD64 with CVMFS enabled;
+- ARM64 with CVMFS enabled;
+- both architectures with CVMFS disabled and OCI pull enabled;
+- local/offline reuse;
+- CLI and GUI wrappers;
+- module load and explicit flavour selection;
+- primary-registry failure and fallback;
+- native referrers and tag-schema fallback;
+- withdrawn/stale release handling; and
+- Neurodesktop startup and its container test suite.
+
+After a published compatibility window:
+
+- stop generating new flat directories;
+- retain aliases for an agreed longer window;
+- remove filename parsing from normal resolution;
+- remove object-store fallback only after usage is measured; and
+- document the final removal release.
+
+## Rollback
+
+Every migration phase must remain reversible:
+
+- immutable legacy OCI tags and SIF objects are retained;
+- legacy CVMFS paths remain materialized or aliased;
+- `apps.json` can point launchers back to the legacy resolver;
+- floating tags can be restored to their previous recorded digests;
+- a failed new CVMFS publish is aborted before the compatibility view changes;
+  and
+- no cleanup of legacy objects occurs until after the compatibility window.
+
+Rollback changes pointers and generated views. It does not rebuild or overwrite
+immutable content.
+
+## Validation requirements
+
+### Neurocontainers
+
+- JSON Schema positive and negative tests.
+- Variant matrix tests for default, ARM, GPU, and combined flavour/platform
+  cases.
+- Tests that architecture aliases normalize to OCI values.
+- Candidate tamper tests for name, version, flavour, platform, build date,
+  index digest, child digest, and SIF digest.
+- Multi-platform promotion tests that refuse partial indexes.
+- Tests that a same-day conflicting immutable release is rejected.
+- Referrer attachment and mirrored-graph verification tests.
+- Fulltest selection from a platform entry without wildcard filenames.
+
+### Neurocommand
+
+- Manifest loading and forward-compatible schema tests.
+- Host-platform and explicit-flavour selection tests.
+- CVMFS path generation tests for every variant rule.
+- Legacy flat-name parsing tests from PR #767.
+- Native referrers, fallback-tag, missing-referrer, multiple-referrer,
+  wrong-subject, wrong-platform, and bad-digest tests.
+- Module generation without a hard-coded mount path.
+- Empty deploy command rejection.
+- Cleanup reachability tests proving hidden and non-active retained releases are
+  not deleted.
+- CVMFS reconciliation tests that use manifest identity rather than regex
+  replacement.
+
+### Neurodesktop
+
+- Startup with an externally mounted CVMFS repository.
+- Startup with an internal FUSE mount.
+- CVMFS-disabled OCI download.
+- AMD64 and ARM64 module selection.
+- Local container persistence across image upgrades.
+- Test-runner lookup through release ID rather than a constructed flat path.
+
+## GitHub context reviewed
+
+As of 2026-07-28, this review inventoried all open items in the two requested
+repositories:
+
+- Neurocommand: 4 open issues and 1 open PR.
+- Neurocontainers: 29 open issues and 2 open PRs.
+
+Directly relevant items:
+
+| Item | Relevance |
+|---|---|
+| [neurocommand#733](https://github.com/neurodesk/neurocommand/issues/733) | ARM publication, variants, parsing breakpoints, artifact cleanup, and maintainer direction. |
+| [neurocommand#152](https://github.com/neurodesk/neurocommand/issues/152) | Module portability, runtime selection, configurable CVMFS mount, and reviewable module generation. |
+| [neurocommand#75](https://github.com/neurodesk/neurocommand/issues/75) | Generated transparent-singularity paths become stale when local storage moves. |
+| [neurocommand#13](https://github.com/neurodesk/neurocommand/issues/13) | Broader packaging of Neurocommand; no direct layout requirement. |
+| [neurocommand#767](https://github.com/neurodesk/neurocommand/pull/767) | Draft end-to-end concrete variant support and the required legacy compatibility parser. |
+| [neurocontainers#1092](https://github.com/neurodesk/neurocontainers/issues/1092) | General CPU/GPU/architecture variation model. |
+| [neurocontainers#1252](https://github.com/neurodesk/neurocontainers/issues/1252) | ARM build infrastructure. |
+| [neurocontainers#2593](https://github.com/neurodesk/neurocontainers/issues/2593) | Same-tag multi-architecture/referrer direction and CVMFS current-snapshot policy. |
+| [neurocontainers#2408](https://github.com/neurodesk/neurocontainers/issues/2408) | v2 OCI repository, immutable tag, SIF referrer, and floating-tag model. |
+| [neurocontainers#2409](https://github.com/neurodesk/neurocontainers/issues/2409) | OCI labels and SIF annotations. |
+| [neurocontainers#2796](https://github.com/neurodesk/neurocontainers/issues/2796) | Fulltest artifact selection from release metadata. |
+| [neurocontainers#1906](https://github.com/neurodesk/neurocontainers/issues/1906) | CVMFS client configuration distribution; mount configuration remains outside this layout proposal. |
+| [neurocontainers#1253](https://github.com/neurodesk/neurocontainers/issues/1253) | CVMFS metrics; useful for measuring cutover and fallback usage. |
+| [neurocontainers#61](https://github.com/neurodesk/neurocontainers/issues/61) | CVMFS scanning; the manifest enables structured reconciliation. |
+| [neurocontainers#218](https://github.com/neurodesk/neurocontainers/issues/218) | Container metadata/database direction. |
+| [neurocontainers#504](https://github.com/neurodesk/neurocontainers/issues/504) | Signing and supply-chain metadata fit the OCI subject graph. |
+| [neurocontainers#2950](https://github.com/neurodesk/neurocontainers/issues/2950) | Registry-native manifest/config access supports the general move away from pulling content to inspect metadata. |
+| [neurocontainers#2913](https://github.com/neurodesk/neurocontainers/pull/2913) | Draft first-class variant builder and release fan-out. |
+| [neurocontainers#2914](https://github.com/neurodesk/neurocontainers/pull/2914) | Draft tested-candidate promotion and manifest foundation. |
+
+The remaining open Neurocontainers issues are application requests or isolated
+build/release failures and do not change the proposed layout.
+
+## Standards and operational references
+
+- [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/main/image-index.md)
+- [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md)
+- [OCI Distribution Specification: referrers and fallback tag schema](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+- [ORAS attached artifacts](https://oras.land/docs/concepts/reftypes/)
+- [ORAS `attach` command](https://oras.land/docs/commands/oras_attach/)
+- [Apptainer OCI registry documentation](https://apptainer.org/docs/user/latest/registry.html)
+- [CVMFS nested catalog recommendations](https://cvmfs.readthedocs.io/en/2.14/cpt-repo/#managing-nested-catalogs)
+- [CVMFS repository integrity checks](https://cvmfs.readthedocs.io/en/stable/cpt-repo.html)
+
+## Alternatives considered
+
+### Keep the flat layout and parse from the right
+
+This is the lowest-risk compatibility step and PR #767 should retain it for old
+identities. It does not remove coupling between storage paths, module names,
+display names, cleanup keys, and registry names, so it is not the target.
+
+### Encode every flavour and architecture into the container name
+
+This matches the first implementation in PR #2913 and is easy for legacy
+Neurocommand consumers. It creates separate OCI repositories and user-facing
+module names for what are otherwise dimensions of one logical tool, and it does
+not implement the same-tag multi-architecture direction in issue #2593.
+
+This proposal preserves distinct concrete variants but stores their axes in the
+manifest and CVMFS release name. Maintainers should explicitly confirm this
+change from the current draft PR direction.
+
+### Publish a separate OCI tag for every architecture
+
+This works with simple clients but moves host selection into tag naming,
+duplicates floating-tag policy, and conflicts with the agreed image-index
+direction. Architecture-specific tags may exist as temporary build inputs, but
+they are not public release identities.
+
+### Attach all SIFs only to the top-level index
+
+Custom annotations could distinguish them, but standard platform resolution
+would not identify one SIF subject. Attaching to each child manifest gives the
+SIF the same platform identity as the runnable image.
+
+### Continue treating `apps.json` as the canonical inventory
+
+`apps.json` is a presentation/publication view. It cannot safely represent
+candidate, hidden, archived, withdrawn, and multi-platform artifacts without
+becoming another release database. Its past use as a cleanup keep-list already
+deleted valid hidden ARM artifacts.
+
+## Questions requiring maintainer decision
+
+| Question | Recommendation |
+|---|---|
+| Should product flavour and platform remain separate internally? | Yes. Derive the single CVMFS `variant` token from both. |
+| Should ARM remain a distinct name such as `fsl_arm64`? | No for the target OCI/CVMFS model; retain it only as a legacy alias. |
+| How should product flavours appear in OCI? | Separate immutable tags/indexes within the same logical repository. |
+| What is the SIF subject? | The exact platform child manifest. |
+| What is the canonical architecture vocabulary? | OCI `amd64` and `arm64`; accept recipe aliases at input. |
+| What is the unpacked CVMFS payload called? | `rootfs`, with temporary legacy inner-name aliases if required. |
+| What is the release-history path in Neurocontainers? | `releases/<name>/<version>/<flavour>/<build_date>.json`. |
+| Which registry is primary? | Ratify Quay-primary versus GHCR-critical; record and verify each registry independently meanwhile. |
+| What happens on a conflicting same-day rebuild? | Fail promotion; approve an extended build ID before allowing it. |
+| How does `module load name/version` select architecture? | Use the shared resolver/platform dispatcher; never fix the module to AMD64. |
+| How long are flat CVMFS aliases retained? | At least one announced Neurodesktop/Neurocommand compatibility cycle, then remove based on observed usage. |
+| Is the legacy `.simg` object-store path retained? | Yes during migration and for rollback; measure use before removal. |
+
+Approval of those decisions is sufficient to split implementation into
+reviewable PRs without requiring a flag day across the three repositories.

--- a/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
+++ b/CONTAINER_DISTRIBUTION_LAYOUT_PROPOSAL.md
@@ -1,584 +1,436 @@
-# Proposal: container identity, CVMFS layout, and OCI manifests
+# Proposal: manifest-backed container distribution
 
 > Status: draft for maintainer review<br>
-> Scope: `neurodesk/neurocontainers`, `neurodesk/neurocommand`, and
-> `neurodesk/neurodesktop`<br>
-> GitHub state reviewed: 2026-07-28
+> Required implementation repositories: `neurodesk/neurocontainers` and
+> `neurodesk/neurocommand`<br>
+> Conditional implementation repository: `neurodesk/neurodesktop`<br>
+> Repository state reviewed: 2026-07-28
 
-## Summary
+## Decision requested
 
-This proposal replaces the flat CVMFS container namespace:
-
-```text
-/containers/<name>_<version>_<builddate>/
-```
-
-with an explicit release hierarchy:
+Adopt a versioned release manifest as the contract between Neurocontainers,
+OCI registries, CVMFS, Neurocommand, and Neurodesktop, and publish new releases
+under:
 
 ```text
-/containers/<name>/<version>_<variant>_<builddate>/
+/containers/<name>/<software-version>_<cvmfs-variant>_<build-date>/
 ```
 
-It also makes a generated release manifest, rather than a parsed filename or an
-`apps.json` display key, the contract between container building, OCI
-publication, CVMFS publication, module generation, local downloads, and
-Neurodesktop.
+For example:
 
-The proposed OCI representation is:
+```text
+/containers/fsl/6.0.7.16_amd64_20260728/
+/containers/fsl/6.0.7.16_arm64_20260728/
+/containers/fsl/6.0.7.16_gpu-amd64_20260728/
+```
 
-- one OCI repository per logical tool, such as `quay.io/neurodesk/fsl`;
-- one immutable tag per software version, product flavour, and build date;
-- an OCI image index at that tag, with one child manifest per supported
-  platform;
-- one SIF artifact attached to each platform-specific child manifest through
-  OCI 1.1 referrers; and
-- one Neurodesk release-manifest artifact attached to the top-level image
-  index.
+The change has five non-negotiable properties:
 
-The important distinction is that a Neurodesk product **flavour** such as
-`default`, `gpu`, `cuda12`, or `mpi` is not an OCI platform variant.
-Architecture selection belongs in the OCI image index. Product flavour remains
-an explicit release dimension and, where necessary, an OCI tag dimension.
+1. A release is identified by logical name, software version, build variant,
+   and build date. A platform artifact adds an OCI platform such as
+   `linux/amd64`.
+2. One immutable OCI tag points to an image index, even when the release
+   currently has only one platform. Each platform-specific SIF is attached to
+   the corresponding child image manifest.
+3. The complete existing CVMFS path remains valid for every newly published
+   release before generated views expose it. Old clients and stored paths do
+   not need to understand manifests.
+4. Existing releases are not moved, rewritten, backfilled, or deleted by this
+   change.
+5. The implementation is delivered as one coordinated merge train with two
+   required linked PRs. A Neurodesktop PR is added only if exact-head testing
+   proves that source changes are necessary.
 
-The recommended change is delivered as one coordinated merge train. The new
-resolver, manifest producer, CVMFS layout, and legacy compatibility views land
-together through linked PRs. New and legacy paths and tags are published in the
-same release, resolve to the same content, and this change does not move or
-delete any existing container.
+This deliberately changes the target distribution model described in
+[neurocommand#733](https://github.com/neurodesk/neurocommand/issues/733).
+Neurocontainers may still fan out concrete build candidates such as
+`fsl_gpu_arm64`, but the published manifest keeps logical name, build variant,
+and platform as separate fields. The old concrete name is retained as an
+explicit compatibility identity.
 
-## Proposed decisions
+## Scope
 
-1. Define a release as the tuple:
+### Included
 
-   ```text
-   (name, software_version, flavour, platform, build_date)
-   ```
+- the release identity and schema;
+- the new CVMFS release path;
+- the complete legacy CVMFS path for each new release;
+- multi-platform OCI indexes and platform-specific SIF referrers;
+- immutable release history;
+- manifest-driven `apps.json`, `cvmfs/log.txt`, modules, launchers, publication,
+  and keep-lists;
+- publication gating so generated views expose only a complete OCI and CVMFS
+  release;
+- a shared Neurocommand resolver for new releases;
+- exact-head testing across the linked PRs; and
+- rollback without deleting immutable content.
 
-2. Derive a concrete CVMFS `variant` identifier from `flavour` and `platform`:
+### Not included
 
-   | Flavour | OCI platform | CVMFS variant |
-   |---|---|---|
-   | `default` | `linux/amd64` | `amd64` |
-   | `default` | `linux/arm64` | `arm64` |
-   | `gpu` | `linux/amd64` | `gpu-amd64` |
-   | `gpu` | `linux/arm64` | `gpu-arm64` |
-   | `cuda12` | `linux/amd64` | `cuda12-amd64` |
+- converting existing CVMFS releases to the new hierarchy;
+- removing flat CVMFS paths, legacy OCI tags, object-store SIFs, or filename
+  parsing;
+- changing `/cvmfs/neurodesk.ardc.edu.au`, the public module roots, or
+  `module load <name>/<version>`;
+- redesigning the full release-withdrawal or retention policy;
+- deleting any object as part of activation;
+- signatures, SBOMs, or attestations beyond leaving room for OCI referrers; or
+- unrelated module portability and packaging work.
 
-3. Keep the logical tool name stable across platforms. For example, ARM FSL is
-   represented as `name=fsl`, `platform=linux/arm64`, rather than requiring
-   `name=fsl_arm64`.
+Keeping these items out is part of the safety case. They can be proposed
+separately after the new contract is operating.
 
-4. Never infer release fields by splitting an application display name, OCI
-   repository, or CVMFS path. Those strings are projections of explicit
-   metadata.
+## Why this change
 
-5. Use an OCI image index for architecture selection. Do not use OCI
-   `platform.variant` for Neurodesk concepts such as `gpu`; OCI defines that
-   field for CPU variants such as ARM `v8` or x86-64 `v2`.
+### The flat name is an accidental schema
 
-6. Attach each SIF to the platform-specific child manifest, not only to the
-   top-level multi-platform index. A SIF is architecture-specific and should
-   have one unambiguous subject.
-
-7. Treat immutable tags and digests as release identities. Floating tags are
-   convenience pointers only and must never be recorded as the reproducibility
-   reference.
-
-8. Generate `apps.json`, CVMFS inventory, modulefiles, cleanup keep-lists, and
-   application lists from release manifests. `cvmfs/log.txt` remains a
-   compatibility output for existing consumers, but not the source of truth.
-
-9. Make the complete existing CVMFS pathname a required compatibility view for
-   every release published in the new layout. Supporting the old resolver alone
-   is insufficient because external users may have stored direct paths.
-
-## Motivation
-
-### The current filename is carrying too many meanings
-
-Current code commonly assumes that a container is exactly:
+Current code commonly treats a release as:
 
 ```text
 <name>_<version>_<YYYYMMDD>
 ```
 
-This assumption appears in:
+That string is parsed independently by:
 
 - [`neurodesk/fetch_containers.sh`](neurodesk/fetch_containers.sh);
 - [`neurodesk/fetch_and_run.sh`](neurodesk/fetch_and_run.sh);
 - [`neurodesk/transparent-singularity/run_transparent_singularity.sh`](neurodesk/transparent-singularity/run_transparent_singularity.sh);
-- [`cvmfs/reconcile_module_files.py`](cvmfs/reconcile_module_files.py);
 - [`cvmfs/sync_containers_to_cvmfs.sh`](cvmfs/sync_containers_to_cvmfs.sh);
+- [`cvmfs/reconcile_module_files.py`](cvmfs/reconcile_module_files.py);
 - [`containers.sh`](containers.sh);
-- [`.github/workflows/upload_containers_simg.sh`](.github/workflows/upload_containers_simg.sh);
-- DOI and stale-object maintenance workflows; and
-- `neurodesktop/config/test_neurodesktop.sh` in the Neurodesktop repository.
+- upload, cleanup, and DOI workflows; and
+- Neurodesktop's
+  [`config/test_neurodesktop.sh`](https://github.com/neurodesk/neurodesktop/blob/main/config/test_neurodesktop.sh).
 
-That works for the 365 current entries in `cvmfs/log.txt`, all of which have
-exactly two underscores. It does not provide a durable grammar for names,
-versions, product flavours, and architectures that may themselves contain
-delimiters.
+Draft [neurocommand#767](https://github.com/neurodesk/neurocommand/pull/767)
+correctly parses legacy names from the right so concrete names containing
+underscores work. That is necessary compatibility hardening, but it should not
+become the schema for new releases.
 
-Draft Neurocommand PR
-[#767](https://github.com/neurodesk/neurocommand/pull/767) correctly makes the
-legacy parser work from the right, allowing concrete names such as
-`fsl_gpu_arm64`. That is a useful compatibility fix, but continuing to improve
-filename parsing would leave the filename as an undocumented database schema.
+### Two active Neurocontainers changes need one release boundary
 
-### Variant and multi-architecture work is already active
+Draft [neurocontainers#2913](https://github.com/neurodesk/neurocontainers/pull/2913)
+fans one recipe out into architecture and named-variant candidates. Draft
+[neurocontainers#2914](https://github.com/neurodesk/neurocontainers/pull/2914)
+builds and tests an unprivileged candidate, then promotes the exact tested
+Docker archive, SIF, checksums, recipe fingerprint, PR, and commit after merge.
 
-The relevant work is not hypothetical:
+They overlap in build and release workflows. Merging both unchanged would leave
+the secure one-PR promotion path AMD64-only while the variant path continues
+through the older release flow. This proposal makes their integration, rather
+than their independent merge, a prerequisite.
 
-- Neurocontainers issue
-  [#1092](https://github.com/neurodesk/neurocontainers/issues/1092) requests
-  first-class container variations.
-- Neurocommand issue
-  [#733](https://github.com/neurodesk/neurocommand/issues/733) tracks ARM
-  publication and contains maintainer direction to make variation a general
-  builder feature.
-- Draft Neurocontainers PR
-  [#2913](https://github.com/neurodesk/neurocontainers/pull/2913) implements
-  variant fan-out for default, ARM, GPU, CUDA, and combined variants.
-- Draft Neurocommand PR
-  [#767](https://github.com/neurodesk/neurocommand/pull/767) adapts deployment,
-  module reconciliation, menu generation, and cleanup to those concrete names.
-- Neurocontainers issue
-  [#2593](https://github.com/neurodesk/neurocontainers/issues/2593) records
-  agreement to publish multi-architecture artifacts under the same OCI tags and
-  let clients select the appropriate object.
+### Presentation metadata is not a safe inventory
 
-The builder fan-out in PR #2913 should be preserved. This proposal changes how
-the resulting axes are represented at the distribution boundary: base name,
-flavour, and platform remain separate fields instead of being recoverable only
-from a concatenated concrete name.
+`apps.json` is a user-facing view. Releases may be hidden from menus while
+their artifacts must still be retained. Neurocommand issue
+[#733](https://github.com/neurodesk/neurocommand/issues/733) records ARM SIFs
+being removed after cleanup used the UI-derived log as its keep-list.
 
-### Release metadata already needs to become authoritative
+An immutable release manifest can generate `apps.json` and `cvmfs/log.txt`, but
+neither generated view should decide whether an artifact exists or is retained.
 
-Neurocontainers issue
-[#2796](https://github.com/neurodesk/neurocontainers/issues/2796) asks full
-tests to resolve an artifact from release metadata instead of hard-coded SIF
-wildcards. Neurocommand issue #733 documents how ARM artifacts that existed in
-release metadata were omitted from `apps.json` and then deleted by cleanup
-because cleanup used the UI publication view as its keep-list.
+## Identity model
 
-Draft Neurocontainers PR
-[#2914](https://github.com/neurodesk/neurocontainers/pull/2914) is a strong
-foundation: it binds a tested Docker archive, SIF, checksum, recipe fingerprint,
-commit, PR, and generated release JSON into a promotion manifest. The layout
-work should extend that manifest to cover every flavour and platform, rather
-than introduce a second metadata path.
+The document uses these terms precisely:
 
-### CVMFS is naturally hierarchical
+| Term | Meaning | Example |
+|---|---|---|
+| Logical name | Stable recipe/tool identity | `fsl` |
+| Software version | Upstream software version | `6.0.7.16` |
+| Build variant | Neurodesk build choice, independent of CPU architecture | `default`, `gpu`, `cuda12` |
+| Build date | Eight-digit UTC release build identifier | `20260728` |
+| Release | One logical build across its supported platforms | `fsl/6.0.7.16/default/20260728` |
+| Platform artifact | One release plus an OCI platform | release + `linux/arm64` |
+| CVMFS variant | Filesystem projection of build variant and platform | `arm64`, `gpu-amd64` |
+| Legacy identity | Complete concrete name used by existing clients | `fsl_arm64_6.0.7.16_20260728` |
 
-CVMFS recommends nested catalogs at software release boundaries because
-releases are normally immutable and clients generally use only one release at a
-time. The new `<name>/<release>` hierarchy gives us a stable place for that
-boundary and avoids putting every release directly in the large
-`/containers` directory.
-
-## Terminology and identity rules
-
-### Logical name
-
-`name` is the stable recipe/tool identity, for example `fsl`, `dcm2niix`, or
-`deepretinotopy`.
-
-- It is the Neurocontainers recipe directory name.
-- It is the OCI repository name.
-- It is the first directory beneath CVMFS `/containers`.
-- It does not include architecture.
-- It does not include the default product flavour.
-
-### Software version
-
-`software_version` is the upstream tool version, not the container build date.
-The existing release JSON field named `version` inside an app currently stores
-the build date, so the new schema must use unambiguous names:
-
-```json
-{
-  "software_version": "6.0.7.16",
-  "build_date": "20260728"
-}
-```
-
-For the proposed underscore-delimited CVMFS release directory, new software
-versions should be restricted to:
+The release identity is:
 
 ```text
-[A-Za-z0-9][A-Za-z0-9.+-]*
+(name, software_version, build_variant, build_date)
 ```
 
-In particular, `_` and `/` are not permitted in a newly published version.
-Existing versions should be audited before enforcing this. Code must still use
-manifest fields rather than parse the release directory.
-
-### Flavour
-
-`flavour` describes a Neurodesk product/build choice such as:
+The platform artifact identity is:
 
 ```text
-default
-gpu
-cuda12
-mpi
-openrecon
+(name, software_version, build_variant, build_date, platform)
 ```
 
-It is independent of CPU architecture. A recipe may constrain a flavour to a
-set of supported platforms.
+This distinction matters. One release manifest and OCI image index can describe
+multiple platform artifacts.
 
-Flavour identifiers should match:
+### Normalization
 
-```text
-[a-z0-9][a-z0-9.-]*
-```
+- Platforms use OCI values such as `linux/amd64` and `linux/arm64`.
+- Recipe inputs such as `x86_64` and `aarch64` are normalized during the build.
+- Build variants use stable lower-case identifiers such as `default`, `gpu`,
+  and `cuda12`.
+- The schema validates every value before using it in a path or OCI tag.
+- `/` and path traversal are forbidden in path components.
+- Clients never recover fields by splitting a path, display name, or OCI tag.
 
-This deliberately excludes `_`, keeping the CVMFS release directory
-human-readable and delimiter-safe.
+The 230 current recipe versions reviewed for this proposal fit OCI tag
+components. The implementation PR must repeat that audit in CI and use one
+checked-in validation rule rather than introducing different shell and Python
+rules.
 
-### Platform
+### CVMFS variant projection
 
-`platform` uses OCI terminology:
+The manifest stores the projection explicitly:
 
-```text
-linux/amd64
-linux/arm64
-```
+| Build variant | Platform | CVMFS variant |
+|---|---|---|
+| `default` | `linux/amd64` | `amd64` |
+| `default` | `linux/arm64` | `arm64` |
+| `gpu` | `linux/amd64` | `gpu-amd64` |
+| `gpu` | `linux/arm64` | `gpu-arm64` |
+| `cuda12` | `linux/amd64` | `cuda12-amd64` |
 
-Recipe aliases such as `x86_64` and `aarch64` can remain accepted at input, but
-release metadata should normalize them to OCI values. If a genuine CPU variant
-is required, it is recorded separately, for example:
+The order is always `<build-variant>-<architecture>`, with `default` omitted.
+Consumers read `cvmfs_variant` from the manifest; they do not reproduce this
+rule.
 
-```json
-{
-  "os": "linux",
-  "architecture": "arm64",
-  "variant": "v8"
-}
-```
+### Immutability
 
-### CVMFS variant
+An immutable tag, manifest path, or CVMFS release directory must not be
+overwritten with different content. Promotion fails when the same
+`(name, software_version, build_variant, build_date)` already exists with
+another digest.
 
-The `variant` in the requested CVMFS path is a concrete, filesystem-safe
-projection of flavour and platform:
+This proposal retains the requested `YYYYMMDD` build date. A second, different
+same-day build is rejected. Extending the build identifier is a future schema
+decision, not an implicit suffix added by one workflow.
 
-```text
-default + amd64 -> amd64
-default + arm64 -> arm64
-gpu     + amd64 -> gpu-amd64
-gpu     + arm64 -> gpu-arm64
-```
+## CVMFS layout and backwards compatibility
 
-This projection is generated and stored in the release manifest as
-`cvmfs_variant`; clients do not reconstruct it.
+### Canonical release
 
-### Build date and immutability
-
-`build_date` remains an eight-digit UTC date:
-
-```text
-YYYYMMDD
-```
-
-An immutable tag or CVMFS release directory must not be overwritten with
-different content. Promotion must fail if the same
-`(name, version, flavour, build_date)` already exists with another digest.
-
-This implies at most one distinct release of a name/version/flavour on a UTC
-date. If same-day rebuilds are required, maintainers should approve an extended
-build identifier such as `YYYYMMDD.2` before implementation. A source commit and
-content digests remain mandatory even when the date is unique.
-
-## Proposed CVMFS layout
-
-Example:
+A newly published AMD64 release looks like:
 
 ```text
 /cvmfs/neurodesk.ardc.edu.au/
-├── containers/
-│   ├── fsl/
-│   │   ├── 6.0.7.16_amd64_20260728/
-│   │   │   ├── .cvmfscatalog
-│   │   │   ├── release.json
-│   │   │   ├── commands.txt
-│   │   │   ├── bin/
-│   │   │   └── rootfs/
-│   │   ├── 6.0.7.16_arm64_20260728/
-│   │   │   └── ...
-│   │   └── 6.0.7.16_gpu-amd64_20260728/
-│   │       └── ...
-│   ├── dcm2niix/
-│   │   └── v1.0.20240202_arm64_20260728/
-│   │       └── ...
-│   └── modules/
-└── neurodesk-modules/
+└── containers/
+    └── fsl/
+        └── 6.0.7.16_amd64_20260728/
+            ├── .cvmfscatalog
+            ├── release.json
+            ├── commands.txt
+            ├── fsl_6.0.7.16_20260728.simg/
+            └── <existing generated wrappers and metadata>
 ```
 
-Each release directory is immutable after a successful publish.
+The inner layout intentionally remains compatible with today's publisher. In
+particular, this proposal does **not** rename the unpacked `.simg` directory to
+`rootfs` or move wrappers into a new `bin` directory. Those changes are not
+needed to introduce the hierarchy and would increase the activation surface.
 
-### Release directory contents
+The release directory is immutable after publication and is a nested catalog
+root. The current nested catalogs inside the unpacked image are preserved until
+separate measurements justify changing them.
 
-`release.json`
-: A byte-for-byte copy of the generated release manifest. It allows inspection
-  without consulting GitHub or an OCI registry.
+### Required legacy path
 
-`rootfs/`
-: The unpacked SIF/sandbox tree served lazily by CVMFS. The current layout uses
-  a directory ending in `.simg`, which looks like a file but is an unpacked
-  directory. `rootfs` makes the on-disk representation explicit.
-
-`commands.txt`
-: The validated command inventory generated from the recipe deploy contract.
-  Publication fails if it is missing or empty.
-
-`bin/`
-: Generated transparent wrappers. Modulefiles prepend this directory, rather
-  than relying on every file in the release root being executable.
-
-Additional generated files such as environment metadata may remain in the
-release root, but every field used to regenerate them must be present in
-`release.json`.
-
-### Required legacy path view
-
-For every canonical release, the same CVMFS transaction must publish its exact
-legacy directory and inner `.simg` pathname. For example:
+The same CVMFS transaction creates the canonical directory and the old outer
+name:
 
 ```text
-/containers/fsl_6.0.7.16_20260728/
-└── fsl_6.0.7.16_20260728.simg/
-
-/containers/fsl/6.0.7.16_amd64_20260728/
-└── rootfs/
+/containers/fsl_6.0.7.16_20260728
+  -> fsl/6.0.7.16_amd64_20260728
 ```
 
-Both paths must expose the same rootfs content. The legacy name is derived from
-explicit manifest compatibility fields, not reconstructed by splitting the new
-path. ARM and flavour aliases are equally explicit, for example:
+The complete old path therefore still works:
 
 ```text
-/containers/fsl_arm64_6.0.7.16_20260728/
-  -> /containers/fsl/6.0.7.16_arm64_20260728/
+/containers/fsl_6.0.7.16_20260728/fsl_6.0.7.16_20260728.simg
 ```
 
-Operationally this is a hard-linked compatibility view: there is one payload
-and two stable namespaces. It cannot be implemented as a literal POSIX hard
-link between the directory trees because directories cannot be hard-linked and
-CVMFS emulates file hard-link groups only within one directory. The publisher
-should therefore use directory and inner-name symlinks where the old client
-tests permit them. If a materialized mirror is required, its regular-file
-entries must have the same CVMFS content hashes as the canonical tree; CVMFS
-content-addressed storage then avoids duplicating payload blobs even though
-both namespaces consume catalog entries.
+ARM and named variants use manifest-declared legacy identities:
 
-Publication fails if an expected legacy pathname is absent, resolves outside
-its declared canonical release, or does not expose the same content. Existing
-materialized legacy releases are left untouched rather than rewritten into
-aliases.
+```text
+/containers/fsl_arm64_6.0.7.16_20260728
+  -> fsl/6.0.7.16_arm64_20260728
 
-### Catalog boundaries
+/containers/fsl_gpu_6.0.7.16_20260728
+  -> fsl/6.0.7.16_gpu-amd64_20260728
+```
 
-Every release directory should be a nested catalog root. Prefer a repository
-policy such as a `.cvmfsdirtab` rule for `/containers/*/*` over ad hoc marker
-creation. That rule must explicitly exclude `/containers/modules/*` and any
-compatibility-alias subtree so they are not accidentally treated as release
-catalogs.
+This meets the requested hard-link intent—one payload with two stable
+namespaces—but the outer directory must be a symbolic link, not a literal
+hard link. POSIX does not support directory hard links, and CVMFS emulates file
+hard-link groups only within one directory. A directory symlink also avoids
+duplicating catalog entries for the unpacked image.
 
-The current publisher also creates nested catalogs inside the unpacked image at
-`usr`, `usr/lib`, and `usr/share`. Those deeper boundaries should initially be
-preserved for compatibility, then retained or removed based on
-`cvmfs_server list-catalogs -e` measurements. A release catalog should generally
-contain more than 1,000 and fewer than roughly 200,000 entries; very large
-rootfs trees may still need internal catalogs.
+If the exact-head integration test finds an old client that cannot use the
+directory symlink, the safe fallback is a generated compatibility directory
+whose payload entries have the same CVMFS content hashes. CVMFS
+content-addressed storage avoids duplicate payload blobs, although the
+compatibility directory would add catalog entries. The linked PR must record
+which representation passed testing; it must not silently omit the old path.
 
-### What CVMFS retains
+### Existing releases
 
-Following the direction in Neurocontainers issue #2593:
+Existing flat releases remain exactly where they are. Neurocommand continues
+to resolve them through the legacy path because they have no schema-v1 release
+manifest. This change does not create canonical aliases for the existing
+catalogue and does not rewrite existing nested catalogs.
 
-- CVMFS stores the current active release snapshot needed for normal execution.
-- Git and OCI retain the full release-manifest history.
-- OCI and archival object storage retain old immutable SIFs by digest.
-- Withdrawal disables the active wrappers/module pointer before payload
-  removal.
-- Reproducibility instructions resolve an old manifest to an OCI digest even
-  after that release is no longer materialized in CVMFS.
+That is a permanent supported condition, not an intermediate deployment state:
 
-An artifact is never deleted merely because it is hidden from a menu or absent
-from `apps.json`.
+- old release without schema v1 → legacy resolver;
+- new release with valid schema v1 → manifest resolver;
+- old client accessing a new release → manifest-declared legacy CVMFS path.
 
-## Proposed OCI layout
+### Publication transaction
 
-### Repositories and tags
+For one release, Neurocommand opens one CVMFS transaction and:
 
-Use one repository per logical name:
+1. materializes the canonical release directory;
+2. writes the exact promoted `release.json`;
+3. preserves the current unpacked `.simg`, wrapper, command, and nested-catalog
+   shape;
+4. creates the complete legacy directory alias;
+5. generates or updates modules and compatibility metadata;
+6. verifies both full paths, a non-empty `commands.txt`, module resolution, and
+   an Apptainer/Singularity execution through each path; and
+7. publishes only if every check passes.
+
+Failure aborts the transaction, leaving the previous CVMFS revision visible.
+No cleanup runs inside this transaction.
+
+## OCI layout
+
+### Repository and tags
+
+Use one repository per logical tool:
 
 ```text
 quay.io/neurodesk/<name>
 ghcr.io/neurodesk/<name>
 ```
 
-Immutable default-flavour tag:
+Immutable default-variant tag:
 
 ```text
-<software_version>_<build_date>
+<software-version>_<build-date>
 ```
 
-Immutable named-flavour tag:
+Immutable named-variant tag:
 
 ```text
-<software_version>_<flavour>_<build_date>
+<software-version>_<build-variant>_<build-date>
 ```
 
-Examples:
+For example:
 
 ```text
 quay.io/neurodesk/fsl:6.0.7.16_20260728
 quay.io/neurodesk/fsl:6.0.7.16_gpu_20260728
 ```
 
-These preserve the v2 direction in Neurocontainers issue
-[#2408](https://github.com/neurodesk/neurocontainers/issues/2408), while adding
-an explicit product-flavour dimension.
+Architecture is not encoded in the repository or tag. Floating tags such as
+`<software-version>` or `latest` remain convenience pointers and are advanced
+last. They are never stored as reproducibility references.
 
-After all immutable objects and metadata have been verified, promotion may
-advance these convenience tags:
+### Subject graph
 
-```text
-<software_version>
-<software_version>_<flavour>
-latest
-```
-
-`latest` refers only to the default flavour. A flavour-specific `latest` tag
-should not be added until there is a concrete client requirement and an agreed
-naming rule.
-
-### Image index
-
-The immutable tag resolves to an OCI image index:
+Every immutable release tag resolves to an OCI image index:
 
 ```text
 fsl:6.0.7.16_20260728
-  ├── linux/amd64 -> image manifest sha256:...
-  └── linux/arm64 -> image manifest sha256:...
+├── linux/amd64 image manifest
+│   └── SIF artifact manifest -> tested AMD64 SIF blob
+├── linux/arm64 image manifest
+│   └── SIF artifact manifest -> tested ARM64 SIF blob
+└── Neurodesk release-manifest artifact
 ```
 
-The index contains standard platform descriptors. Architecture must not also be
-encoded into the OCI repository name or immutable tag.
+An index is used even for a release with one platform so clients and promotion
+code have one stable shape.
 
-A named product flavour gets another index:
-
-```text
-fsl:6.0.7.16_gpu_20260728
-  └── linux/amd64 -> image manifest sha256:...
-```
-
-If a flavour later supports ARM, an ARM child can be added only while the
-release is still a candidate. An immutable published index must never be
-mutated; a changed platform set requires a new build date.
-
-### SIF artifacts
-
-Attach a SIF to each child image manifest with:
+The SIF artifact manifest has:
 
 ```text
 artifactType: application/vnd.sylabs.sif.layer.v1.sif
-subject:       <platform-specific image-manifest digest>
+subject:       <exact platform child image-manifest digest>
 ```
 
-Recommended descriptor/manifest annotations include:
+The release-manifest artifact has the top-level image index as its subject. The
+release manifest records the selected child and SIF artifact digests, so a
+runtime does not choose `.manifests[0]` from an untrusted referrers response.
 
-```text
-org.opencontainers.image.title
-org.opencontainers.image.version
-org.opencontainers.image.created
-org.neurodesk.name
-org.neurodesk.software-version
-org.neurodesk.flavour
-org.neurodesk.platform
-org.neurodesk.build-date
-org.neurodesk.sif.sha256
-```
+The publisher supports the OCI 1.1 referrers API and the standard fallback tag
+schema. Each registry listed in a release manifest must contain a complete,
+verified subject graph. A release requires at least one complete registry; a
+best-effort mirror is listed only after its copy is verified.
 
-The labels proposed in Neurocontainers issue
-[#2409](https://github.com/neurodesk/neurocontainers/issues/2409) remain
-applicable to the runnable image manifests. Equivalent annotations should be
-placed on the index and SIF artifact where useful.
+### Promotion order
 
-The resolver must:
+Immutable candidate objects are not active merely because they exist in a
+registry. Trusted promotion:
 
-1. resolve an immutable tag to the top-level index digest;
-2. select the exact child descriptor for the host/requested platform;
-3. query referrers for that child digest;
-4. filter by the SIF artifact type;
-5. verify each returned manifest's subject, platform annotations, and expected
-   checksum;
-6. reject zero or multiple matching SIFs unless the release manifest identifies
-   one exact digest; and
-7. pull the SIF by digest, never by a floating tag.
+1. verifies every required build-variant/platform candidate against its PR head
+   SHA and recipe fingerprint;
+2. pushes and verifies the child image manifests and tested SIF artifacts, and
+   verifies the manifest-declared legacy object-store keys;
+3. creates and verifies the complete image index;
+4. resolves post-push digests for every recorded registry;
+5. generates and validates the immutable release manifest;
+6. attaches the release manifest to the index and commits the same JSON to
+   trusted release history;
+7. asks Neurocommand to publish the canonical and legacy CVMFS paths; and
+8. after Neurocommand acknowledges that CVMFS revision, updates generated
+   presentation views and floating tags.
 
-The current transparent-singularity implementation takes the first matching
-referrer. That is sufficient as an initial v2 experiment but is not a durable
-selection rule.
+A failure before step 6 leaves only immutable registry objects. A failure in
+steps 6 or 7 leaves an immutable manifest in release history but no generated
+view selects it. A partial platform set or missing legacy CVMFS path is never
+represented as an available release.
 
-### Registry compatibility
-
-OCI Distribution 1.1 defines the native
-`/v2/<name>/referrers/<digest>` endpoint and requires clients to fall back to
-the referrers tag schema when that endpoint returns `404`.
-
-Quay currently exposes a native referrers endpoint. The current Neurocommand
-code uses native referrers for Quay and the tag-schema fallback for GHCR. The
-shared resolver should implement the OCI fallback once rather than maintain
-registry-specific `curl` pipelines in shell.
-
-Neurocontainers issue #2408 describes Quay as primary and GHCR as a mirror,
-whereas PR #2914 currently treats GHCR as release-critical and Quay as
-best-effort. Until maintainers ratify one policy, the release manifest should
-record an ordered registry list with a separate index, child, and SIF digest for
-each registry. Clients must not assume different registries preserve identical
-manifest digests.
+Legacy object-store SIFs remain published and retained by this change. They are
+compatibility inputs and rollback assets, not the source of truth for new
+releases.
 
 ## Release manifest
 
-### Storage
+### Ownership and storage
 
-Replace the current one-file-per-version history:
-
-```text
-releases/<name>/<version>.json
-```
-
-with:
+Neurocontainers owns the schema and immutable release history:
 
 ```text
-releases/<name>/<software_version>/<flavour>/<build_date>.json
+schemas/container-release-v1.schema.json
+releases/<name>/<software-version>/<build-variant>/<build-date>.json
 ```
 
-For example:
+The candidate manifest introduced by `neurodesk/neurocontainers#2914` and the
+release manifest in this proposal are different:
 
-```text
-releases/fsl/6.0.7.16/default/20260728.json
-releases/fsl/6.0.7.16/gpu/20260728.json
-```
+- the candidate manifest binds untrusted PR outputs to a tested commit before
+  promotion;
+- the release manifest records the verified, post-push distribution graph.
 
-This retains rebuild history instead of replacing the previous metadata for a
-software version. A generated `latest.json` may exist as a compatibility view,
-but it must contain or resolve to an immutable release ID.
+The release manifest is immutable and contains no mutable lifecycle `status`.
+Committing it to trusted release history records a published distribution
+graph, but does not by itself make the release selectable. Selection occurs
+only after Neurocommand acknowledges the CVMFS revision containing both paths
+and promotion regenerates the presentation views. A future withdrawal can
+change those views or add a separate tombstone while retaining the historical
+manifest and digests; that mechanism is outside this proposal.
 
-The same canonical JSON is:
+The identical release JSON is:
 
 - committed by the trusted Neurocontainers promotion workflow;
-- attached as
-  `application/vnd.neurodesk.container-release.v1+json` to the top-level OCI
-  index;
-- copied to the CVMFS release directory; and
-- consumed when generating Neurocommand views.
+- attached to the OCI image index;
+- copied into the canonical CVMFS release directory; and
+- consumed by Neurocommand to generate compatibility and presentation views.
+
+Neurocommand vendors or fetches the schema with a recorded SHA-256. CI in both
+repositories must fail if their schema bytes or fixtures differ.
 
 ### Illustrative schema
 
-This is a discussion schema, not a final JSON Schema:
+This example establishes field relationships; the implementation PR supplies
+the final JSON Schema:
 
 ```json
 {
@@ -586,9 +438,8 @@ This is a discussion schema, not a final JSON Schema:
   "release_id": "fsl/6.0.7.16/default/20260728",
   "name": "fsl",
   "software_version": "6.0.7.16",
-  "flavour": "default",
+  "build_variant": "default",
   "build_date": "20260728",
-  "status": "published",
   "source": {
     "repository": "neurodesk/neurocontainers",
     "recipe": "recipes/fsl",
@@ -603,13 +454,13 @@ This is a discussion schema, not a final JSON Schema:
         "index_digest": "sha256:...",
         "platforms": {
           "linux/amd64": {
-            "manifest_digest": "sha256:...",
+            "image_manifest_digest": "sha256:...",
             "sif_manifest_digest": "sha256:...",
             "sif_blob_digest": "sha256:...",
             "sif_sha256": "..."
           },
           "linux/arm64": {
-            "manifest_digest": "sha256:...",
+            "image_manifest_digest": "sha256:...",
             "sif_manifest_digest": "sha256:...",
             "sif_blob_digest": "sha256:...",
             "sif_sha256": "..."
@@ -618,23 +469,22 @@ This is a discussion schema, not a final JSON Schema:
       }
     ]
   },
-  "cvmfs": {
-    "repository": "neurodesk.ardc.edu.au",
-    "platforms": {
-      "linux/amd64": {
-        "variant": "amd64",
-        "path": "containers/fsl/6.0.7.16_amd64_20260728",
-        "legacy_rootfs_paths": [
-          "containers/fsl_6.0.7.16_20260728/fsl_6.0.7.16_20260728.simg"
-        ]
-      },
-      "linux/arm64": {
-        "variant": "arm64",
-        "path": "containers/fsl/6.0.7.16_arm64_20260728",
-        "legacy_rootfs_paths": [
-          "containers/fsl_arm64_6.0.7.16_20260728/fsl_arm64_6.0.7.16_20260728.simg"
-        ]
-      }
+  "platforms": {
+    "linux/amd64": {
+      "cvmfs_variant": "amd64",
+      "cvmfs_release_path": "containers/fsl/6.0.7.16_amd64_20260728",
+      "cvmfs_payload_path": "containers/fsl/6.0.7.16_amd64_20260728/fsl_6.0.7.16_20260728.simg",
+      "legacy_release_path": "containers/fsl_6.0.7.16_20260728",
+      "legacy_payload_path": "containers/fsl_6.0.7.16_20260728/fsl_6.0.7.16_20260728.simg",
+      "legacy_object_keys": ["fsl_6.0.7.16_20260728.simg"]
+    },
+    "linux/arm64": {
+      "cvmfs_variant": "arm64",
+      "cvmfs_release_path": "containers/fsl/6.0.7.16_arm64_20260728",
+      "cvmfs_payload_path": "containers/fsl/6.0.7.16_arm64_20260728/fsl_arm64_6.0.7.16_20260728.simg",
+      "legacy_release_path": "containers/fsl_arm64_6.0.7.16_20260728",
+      "legacy_payload_path": "containers/fsl_arm64_6.0.7.16_20260728/fsl_arm64_6.0.7.16_20260728.simg",
+      "legacy_object_keys": ["fsl_arm64_6.0.7.16_20260728.simg"]
     }
   },
   "deploy": {
@@ -663,559 +513,388 @@ This is a discussion schema, not a final JSON Schema:
 }
 ```
 
-The final schema should have a checked-in JSON Schema, a schema version, and
-validation in both repositories. Unknown additive fields should be tolerated
-within a schema version; missing identity, digest, platform, or deploy fields
-should fail publication.
+Required identity, source, platform, digest, path, and deploy fields fail
+validation when absent. Unknown additive fields may be accepted within schema
+version 1, but they cannot change the meaning of an existing field.
 
-## Resolution flow
+## Resolution and generated views
 
-```mermaid
-flowchart LR
-    A[Recipe + variant declaration] --> B[Tested per-platform candidates]
-    B --> C[Trusted promotion]
-    C --> D[Canonical release manifest]
-    D --> E[OCI image index]
-    D --> F[Platform SIF referrers]
-    D --> G[CVMFS release directories]
-    D --> H[apps.json and module views]
-    H --> I[Neurocommand / Neurodesktop resolver]
-    I -->|matching CVMFS path exists| G
-    I -->|CVMFS unavailable| E
-    E --> F
-```
+For a schema-v1 release, the shared Neurocommand resolver:
 
-At runtime:
+1. loads the exact `release_id` named by a generated launcher or module entry
+   from trusted release history;
+2. validates the schema and release identity;
+3. normalizes the host platform and selects its exact platform entry;
+4. uses `cvmfs_payload_path` when it exists;
+5. otherwise pulls the recorded SIF artifact manifest digest from the first
+   complete reachable registry and verifies its subject and blob checksum; and
+6. reports the release ID, platform, path, and digests on failure.
 
-1. A launcher identifies an app by a stable app ID and release ID, not by
-   splitting its label.
-2. The resolver determines the requested flavour and normalizes the host
-   platform.
-3. It selects the platform entry from the release manifest.
-4. If the recorded CVMFS release and `rootfs` exist, it executes that release.
-5. Otherwise it resolves the recorded OCI index and child digest, discovers the
-   exact SIF referrer, verifies it, and pulls it to local storage.
-6. Object-storage URLs and legacy OCI layouts remain last-resort compatibility
-   fallbacks for releases without a valid manifest.
+For a release without a valid schema-v1 manifest, Neurocommand uses the existing
+legacy resolver. This capability detection is automatic; there is no manually
+coordinated feature flag.
 
-This same resolver should be used by:
+The same resolver library or CLI is used by launchers, local download,
+CVMFS preflight, full tests, and diagnostics. Shell entrypoints consume
+structured output rather than implementing separate registry and naming logic.
 
-- `fetch_and_run.sh`;
-- `fetch_containers.sh`;
-- transparent-singularity installation;
-- fulltest artifact selection;
-- CVMFS publication preflight;
-- stale-object cleanup; and
-- diagnostic tooling.
+### Compatibility outputs
 
-The implementation can be a small Python CLI/library shipped by Neurocommand.
-Shell entrypoints should call it and consume structured JSON output. Repeating
-OCI token, manifest, referrer, and filename parsing in multiple shell scripts
-would recreate the current coupling.
+For new releases, Neurocommand generates from the manifest:
 
-## Repository responsibilities
+- `apps.json`;
+- `cvmfs/log.txt`;
+- the CVMFS publication inventory;
+- modulefiles and launchers; and
+- cleanup keep-list entries for both canonical and legacy identities.
 
-### `neurodesk/neurocontainers`
+The formats consumed by old clients remain valid. `apps.json` and
+`cvmfs/log.txt` are generated views, not release authority, and are updated
+only after the CVMFS publication acknowledgement. In particular,
+`cvmfs/log.txt` continues to list the manifest's legacy concrete identity so
+existing scripts and cleanup jobs see the same name they understand.
 
-Neurocontainers owns the declared and built identity:
-
-- recipe schema for product flavours and supported platforms;
-- normalization of architecture aliases;
-- per-flavour/per-platform candidate fan-out;
-- coordinated testing of every index child;
-- generation and validation of the release manifest;
-- immutable OCI image publication;
-- multi-platform index creation;
-- per-platform SIF attachment;
-- provenance, checksum, and optional signature/attestation creation;
-- release-history storage; and
-- generated application metadata.
-
-PR #2913 supplies much of the fan-out logic. It should be adapted so that
-`name`, `flavour`, and `platform` survive as separate fields through the
-builder, rather than only producing names such as `fsl_gpu_arm64`.
-
-PR #2914 supplies the secure candidate-to-promotion boundary. It needs to:
-
-- matrix over concrete flavour/platform candidates;
-- include those fields in its candidate manifest and verification;
-- promote all required children as one coordinated release;
-- create the image index only after all required children pass;
-- attach the tested SIF to each child digest;
-- record post-push digests in the canonical release manifest; and
-- update floating tags only after the immutable graph is complete.
-
-The two draft PRs overlap heavily and should be rebased or integrated before
-implementation of this proposal. Merging both unchanged would leave the one-PR
-flow x86-only and the variant flow on the older release path.
-
-### `neurodesk/neurocommand`
-
-Neurocommand owns materialization and client resolution:
-
-- validate/import Neurocontainers release manifests;
-- generate `apps.json` without encoding identity in display keys;
-- generate the compatibility `cvmfs/log.txt` while it is still required;
-- publish the new CVMFS hierarchy;
-- generate modules and wrappers from manifest fields;
-- resolve local, CVMFS, and OCI locations;
-- select host platform and requested flavour;
-- verify OCI subjects and SIF digests;
-- retain legacy local/object-store fallbacks without removing them in this
-  change;
-- drive cleanup from release state and retention policy; and
-- report actionable diagnostics.
-
-PR #767 remains valuable as a legacy parser and safety improvement. Its
-right-hand parsing should be retained for old flat identities, but new paths
-must use manifest fields directly.
-
-### `neurodesk/neurodesktop`
-
-Neurodesktop remains a consumer:
-
-- install the manifest-backed Neurocommand resolver;
-- keep CVMFS mounting and regional endpoint selection;
-- configure the module path exposed by the new module view;
-- use the resolver in container integration tests instead of constructing a
-  flat CVMFS path; and
-- keep local/offline containers compatible with the same release-directory
-  shape.
-
-No change to the CVMFS repository mount point is proposed:
+The public module roots and default user interface remain:
 
 ```text
-/cvmfs/neurodesk.ardc.edu.au
-```
-
-The changes are below its `containers` directory and in the generated module
-contents.
-
-## Known code impact
-
-This is the minimum inventory identified during review.
-
-| Repository | Area | Current assumption to remove or bridge |
-|---|---|---|
-| neurocommand | `neurodesk/write_log.py` | App display name plus build date produces the image ID. |
-| neurocommand | `neurodesk/build_menu.py` | Display-name parsing derives container and version arguments. |
-| neurocommand | `neurodesk/fetch_and_run.sh` | Resolves only a build date and constructs a module name. |
-| neurocommand | `neurodesk/fetch_containers.sh` | Constructs `IMG_NAME=name_version_date`. |
-| neurocommand | `transparent-singularity/run_transparent_singularity.sh` | Parses identity from underscores and contains registry-specific referrer logic. |
-| neurocommand | `cvmfs/sync_containers_to_cvmfs.sh` | Iterates `log.txt`, creates a flat release directory, and preflights only a legacy object key. |
-| neurocommand | `cvmfs/reconcile_module_files.py` | Parses image strings and rewrites paths with a flat-name regex. |
-| neurocommand | `containers.sh` | Splits every log line into name/version/date columns. |
-| neurocommand | `maintenance/fix_missing_bindpath-directories-on-cvmfs.sh` | Globs `/containers/*/*.simg`. |
-| neurocommand | upload/cleanup workflows | Derive legacy object names by underscore fields and use `apps.json`/`log.txt` as retention truth. |
-| neurocommand | DOI workflow | Derives the recipe name from the first underscore-delimited field. |
-| neurodesktop | `config/jupyter/environment_variables.sh` | Hard-codes current local and CVMFS module directories. |
-| neurodesktop | `config/test_neurodesktop.sh` | Constructs `/containers/package_version_date/package_version_date.simg`. |
-| neurodesktop | Dockerfile/startup | Wires local container storage to Neurocommand's current `containers` directory. |
-| neurocontainers | `builder/release.py` | Generates legacy ARM-specific app/image names. |
-| neurocontainers | `tools/generate_apps_json.py` | Merges one mutable release file per version and currently skips legacy ARM releases. |
-| neurocontainers | build/release workflows | Publish individual images before a coordinated multi-platform release graph exists. |
-| neurocontainers | fulltest tooling | Historically resolves dated SIF filenames rather than a manifest platform entry. |
-
-Tests containing literal flat paths must be updated or retained as explicit
-legacy-compatibility tests, not mechanically replaced.
-
-## Modules and application UX
-
-The CVMFS storage identity and user-facing module identity should be separate.
-
-Recommended module behaviour:
-
-```text
+/cvmfs/neurodesk.ardc.edu.au/containers/modules
+/cvmfs/neurodesk.ardc.edu.au/neurodesk-modules
 module load fsl/6.0.7.16
 ```
 
-selects the default flavour for the host platform.
-
-An explicit flavour may be exposed as:
+The default module selects the host platform. A named build variant is exposed
+without changing the logical tool name:
 
 ```text
 module load fsl/6.0.7.16-gpu
 ```
 
-The modulefile should not point permanently at an AMD64 path in a repository
-also mounted on ARM. It can call a small resolver-generated dispatcher, or
-module generation can emit platform-specific logic using a normalized
-environment value set by Neurocommand/Neurodesktop.
+If a concrete module name such as `fsl_gpu/6.0.7.16` was previously published,
+it remains as a compatibility alias. Module generation may call a
+CVMFS-hosted dispatcher to choose the manifest's platform path, but existing
+module names and roots do not disappear in this change.
 
-This work should also address the broader concerns in Neurocommand issue
-[#152](https://github.com/neurodesk/neurocommand/issues/152):
+### Cleanup boundary
 
-- do not hard-code the CVMFS mount location into generated module content;
-- allow Apptainer or Singularity runtime selection;
-- keep generated module sources reviewable in Git;
-- make runtime flags configurable; and
-- leave room for meta-modules.
+Before producer activation, the Neurocommand PR adds schema-v1 releases and
+their compatibility identities to the keep set. Existing cleanup may continue
+under its current policy, but the linked change must not make either namespace
+eligible for deletion and must not delete legacy OCI, object-store, or CVMFS
+content.
 
-An application label such as `FSLeyes 6.0.7.16` remains presentation only.
-Generated launchers receive explicit `release_id`, `app_id`, and optional
-`flavour`; quoting is mandatory.
+The exact-head cleanup dry run must prove that:
 
-## Cleanup, withdrawal, and reproducibility
+- every release manifest is reachable independently of menu visibility;
+- canonical and legacy CVMFS paths are treated as one retained payload;
+- every recorded child manifest and referrer is retained; and
+- existing releases without schema v1 remain in the legacy keep set.
 
-Release status should be explicit:
+Changing the broader retention or withdrawal policy is outside this proposal.
 
-```text
-candidate -> published -> active -> deprecated -> withdrawn
-```
+## Repository ownership
 
-- `published` means the immutable OCI graph and canonical manifest exist.
-- `active` means normal apps/modules may select it and CVMFS should materialize
-  it.
-- `deprecated` remains runnable but is not the preferred floating target.
-- `withdrawn` removes normal launchers/module pointers and records the reason.
+### Neurocontainers
 
-Cleanup computes reachability from all non-purged release manifests, not from
-the subset visible in `apps.json`.
+Neurocontainers owns:
 
-Before deletion it must account for:
+- recipe build-variant and platform declarations;
+- candidate fan-out and testing;
+- candidate-to-promotion verification;
+- the release JSON Schema and immutable history;
+- OCI image indexes, child manifests, and SIF referrers;
+- post-push digest verification; and
+- generation of trusted release inputs for Neurocommand.
 
-- every configured registry copy;
-- OCI child manifests and their referrers;
-- object-store SIFs;
-- the CVMFS materialized path;
-- floating tags;
-- release manifests;
-- an explicit retention interval; and
-- withdrawal/reproducibility policy.
+The producer PR must integrate the fan-out in
+`neurodesk/neurocontainers#2913` with the promotion boundary in
+`neurodesk/neurocontainers#2914`. The two drafts should not merge independently
+in their current form.
 
-Dry-run output and tests are required. A UI visibility change must never make a
-release eligible for deletion.
+### Neurocommand
 
-For withdrawn CVMFS content, update modules/wrappers and publish that revision
-before removing `rootfs`. Old release metadata must retain an exact OCI digest
-and explain how to reproduce the pull. This preserves the intent of the current
-stale-container wrapper while avoiding reconstruction of a legacy Docker
-reference from a filename.
+Neurocommand owns:
 
-## Security and integrity
+- schema validation and platform selection;
+- manifest-driven generated views;
+- canonical and legacy CVMFS publication in one transaction;
+- modules, launchers, and local download resolution;
+- legacy parsing and fallback;
+- compatibility keep-list generation; and
+- failure diagnostics.
 
-- Resolve tags once, then pin and record digests.
-- Verify the platform child belongs to the expected index.
-- Verify a SIF artifact manifest refers to the selected child digest.
-- Verify artifact type, Neurodesk identity annotations, blob digest, and SIF
-  SHA-256 before execution or CVMFS publication.
-- Do not select `.manifests[0]` without comparison to the canonical release
-  manifest.
-- Preserve the candidate checks, recipe fingerprint, PR number, head commit,
-  Docker checksum, and SIF checksum introduced by PR #2914.
-- Make index assembly an atomic promotion gate: no release manifest or floating
-  tag is published until all required children pass.
-- Record per-registry digests and verify copies after mirroring.
-- Run `cvmfs_server check -s <release-path>` for pilots and regularly run the
-  repository integrity checker.
+The legacy right-hand parser and deployment safety checks in
+`neurodesk/neurocommand#767` remain useful. New schema-v1 paths are read from
+the manifest, not parsed.
 
-Container signing and attestations from Neurocontainers issue
-[#504](https://github.com/neurodesk/neurocontainers/issues/504) can be added to
-the same OCI subject graph without another naming scheme. The manifest schema
-should reserve typed referrer entries for signatures, SBOMs, provenance, and
-security scan results.
+### Neurodesktop
 
-## Coordinated merge plan
+Neurodesktop continues to consume:
 
-This is one cross-repository change, not a sequence of independently deployed
-states. The implementation PRs can be reviewed independently, but they remain
-draft and are validated together at their exact head commits. They are merged
-in one scheduled window only when the complete set is ready.
+- the same CVMFS mount;
+- the same public module roots;
+- the same module names;
+- the same local container root; and
+- valid legacy CVMFS paths.
+
+Its current hard-coded container test should pass unchanged through the legacy
+alias. That is valuable compatibility evidence, not automatically a reason to
+change Neurodesktop. A source PR is opened only if the exact-head run exposes a
+real incompatibility.
+
+## One coordinated merge train
 
 ### Linked PR set
 
-| Order | Repository | PR contents | Merge condition |
+| Order | Repository | Required contents | Activation behaviour |
 |---|---|---|---|
-| 1 | `neurodesk/neurocommand` | Versioned schema consumer, manifest resolver, new and legacy CVMFS views, generated metadata, modules, cleanup reachability, and compatibility tests. The resolver uses the legacy path whenever a complete valid schema-v1 manifest is absent. | Required; safe and dormant before the producer PR merges. |
-| 2 | `neurodesk/neurodesktop` | Consume the resolver for startup and integration tests; remove hard-coded flat container and module paths. | Expected from the current code audit. Omit only if the cross-repository test proves Neurodesktop needs no source change. |
-| 3 | `neurodesk/neurocontainers` | Integrate the variant fan-out from #2913 with the tested candidate promotion from #2914; produce the canonical manifest, multi-platform index, SIF referrers, and immutable release history. | Required and merged last because a valid published manifest activates the new path. |
+| 1 | `neurodesk/neurocommand` | Schema consumer, resolver, manifest-generated compatibility outputs, canonical plus legacy CVMFS publication, module dispatch, keep-list hardening, and tests. | Dormant for releases without schema v1; legacy behaviour remains. |
+| 2 | `neurodesk/neurodesktop` | Only the smallest source change demonstrated necessary by exact-head testing. | Conditional; no PR is preferred when current source passes. |
+| 3 | `neurodesk/neurocontainers` | One integrated or superseding implementation of `neurodesk/neurocontainers#2913` and `neurodesk/neurocontainers#2914`: matrix candidates, complete promotion, schema, OCI graph, and immutable release history. | Merged last; the first trusted schema-v1 release activates the new path for that release. |
 
-This proposal PR, `neurodesk/neurocommand#777`, is the tracker and contract
-review. Every implementation PR body must contain:
+There are two required implementation PRs, not three. If Neurodesktop needs no
+source change, its tested commit or image digest is recorded on the two required
+PRs and this tracker.
+
+Every implementation PR body contains:
 
 ```text
 Part of neurodesk/neurocommand#777
 Depends on <exact linked PR URLs>
-Merge order: neurocommand -> neurodesktop (if required) -> neurocontainers
+Tested with:
+- neurocommand: <commit SHA>
+- neurocontainers: <commit SHA>
+- neurodesktop: <commit SHA or image digest>
+Merge order: neurocommand -> neurodesktop (only if required) -> neurocontainers
 ```
 
-The bodies also link #2913 and #2914 and state whether they are integrated,
-superseded, or must be rebased. A PR must not claim the coordinated change is
-ready while one of its required links is missing or still failing.
+The Neurocontainers PR also states explicitly whether
+`neurodesk/neurocontainers#2913` and `neurodesk/neurocontainers#2914` are
+integrated, superseded, or closed in favour of it. The Neurocommand PR does the
+same for
+`neurodesk/neurocommand#767`: it either uses that PR as its base, incorporates
+its legacy fixes, or supersedes it with equivalent tests.
 
-### Cross-repository contract
+### Exact-head proof before merge
 
-- The linked PRs use the same schema version, identity rules, fixtures, and
-  expected digests. The CI record identifies every tested PR head SHA.
-- Capability detection is data-driven, not a manually coordinated feature
-  flag. Neurocommand selects the new path only for a complete schema-v1
-  manifest that passes schema, identity, subject, platform, and digest checks;
-  otherwise it follows the existing path.
-- New and legacy paths, module views, tags, and generated metadata are outputs
-  of the same canonical release manifest.
-- Existing flat CVMFS paths, OCI tags, and object-store SIFs are retained. Their
-  removal is outside this linked PR set and requires a separate proposal based
-  on usage data and the supported-client policy.
-- Every canonical CVMFS release has its complete legacy directory and inner
-  `.simg` pathname in the same transaction. Both namespaces resolve to the same
-  content hashes.
-- No new code outside the explicit compatibility adapter derives identity by
-  splitting filenames, display labels, OCI repositories, or CVMFS paths.
-- Cleanup is disabled for the new identity until reachability tests cover both
-  views. Nothing in this change makes legacy content eligible for deletion.
+All linked PRs remain draft until one reproducible run checks out their exact
+head commits. That run builds a release fixture containing:
 
-### Pre-merge proof
+- `default` on AMD64 and ARM64 under one OCI index;
+- one named build variant such as `gpu`;
+- an immutable release manifest with exact registry and CVMFS paths; and
+- generated old and new Neurocommand views.
 
-A cross-repository CI or reproducible maintainer run checks out the exact heads
-of all linked PRs and builds one representative release graph. It must cover:
+It then proves:
 
-- a default AMD64 and ARM64 release from one logical tool name;
-- one non-default flavour such as `gpu`;
-- schema rejection and fallback when the manifest is missing, incomplete, or
-  has an unexpected version;
-- SIF selection by child digest with native referrers and the documented
-  fallback-tag scheme;
-- CVMFS enabled and disabled, local/offline reuse, module loading, CLI and GUI
-  wrappers, and Neurodesktop startup;
-- primary-registry failure and verified fallback;
-- generation of `apps.json`, `log.txt`, modulefiles, new paths, and legacy
-  compatibility paths from the same manifest;
-- an old Neurocommand/Neurodesktop client running the compatibility path;
-- every declared `legacy_rootfs_paths` entry working directly without a
-  resolver and exposing the canonical rootfs content hash; and
-- dry-run cleanup proving active, hidden, compatibility, and retained releases
-  remain reachable.
+- schema equality and positive/negative validation in both repositories;
+- candidate tamper detection for source, platform, and every recorded digest;
+- refusal to promote a missing or failed platform child;
+- native-referrers and fallback-tag publication;
+- exact SIF selection by recorded digest;
+- canonical and full legacy CVMFS paths execute the same content;
+- the unchanged Neurodesktop container test can use the legacy path;
+- modules work on AMD64 and ARM64 without changing their public name or root;
+- CVMFS-disabled and local/offline paths work;
+- a missing, incomplete, or unsupported manifest returns to legacy resolution;
+- registry failure uses only another complete, verified registry entry;
+- CVMFS failure aborts publication and leaves the previous revision visible;
+  and
+- cleanup dry-run retains existing, hidden, canonical, and legacy releases.
 
-The resulting manifest, digests, generated-file diff, CVMFS path listing, and
-test results are attached to or linked from every required PR. Testing branch
-names or moving default branches is insufficient; the evidence must name the
-commit SHAs that will merge.
+The manifest, resolved digests, generated-file diff, CVMFS path listing, test
+results, and tested SHAs are linked from each required PR. Testing branch names
+or moving default branches is not sufficient evidence.
 
-### Atomic activation
+### Merge and activation window
 
-GitHub, OCI registries, and CVMFS do not share a distributed transaction.
-Atomicity here means no client can select an incomplete release: the canonical
-manifest is the activation record, it is published only after the OCI graph is
-complete, and absence of the CVMFS path sends the resolver to the digest-pinned
-OCI artifact.
+The linked PRs merge in the table order during one scheduled window. This is an
+ordered merge, not a multi-stage deployment:
 
-The OCI publisher may push immutable candidate blobs and child manifests while
-testing, because those objects do not activate a release. It then:
+1. merge the backwards-compatible Neurocommand consumer;
+2. merge the Neurodesktop compatibility fix only if the proof required one;
+3. merge the integrated Neurocontainers producer; and
+4. promote one already-tested schema-v1 release and observe its OCI, CVMFS, old
+   path, new path, module, and Neurodesktop checks before closing the window.
 
-1. verifies every required flavour/platform child and SIF;
-2. creates and verifies the image index and referrer graph;
-3. records registry-resolved digests in the canonical release manifest;
-4. publishes that immutable manifest; and
-5. advances convenience/floating pointers last.
+GitHub, OCI registries, and CVMFS cannot share one distributed transaction.
+Safety comes from two per-release commit points:
 
-A failure before the final two steps leaves only unreachable immutable
-candidates and does not expose a partial release to clients.
+- trusted release history records only a complete OCI graph; and
+- one CVMFS transaction publishes the canonical and legacy paths together.
 
-CVMFS publication uses one repository transaction. Within it, Neurocommand
-materializes `/containers/<name>/<version>_<variant>_<builddate>`, generates the
-new module view, and creates or preserves the required legacy compatibility
-view. It validates the rootfs, commands, release manifest, modules, paths, and
-legacy resolution before publishing the transaction. On failure it aborts the
-transaction, leaving the previous CVMFS revision visible.
+Generated views select the release only after both commit points succeed. A new
+client can still use the recorded OCI SIF when CVMFS is temporarily unavailable
+after activation. An old client first sees the release only after its legacy
+CVMFS path is published.
 
-For example, a tested directory alias may be:
+### Go/no-go checklist
 
-```text
-/containers/fsl_6.0.7.16_20260728
-  -> /containers/fsl/6.0.7.16_amd64_20260728
-```
+The merge window proceeds only when:
 
-The canonical release must also expose the legacy inner
-`fsl_6.0.7.16_20260728.simg` name as a view of `rootfs` so the complete stored
-path continues to work. An existing materialized legacy path is never replaced
-merely to introduce the alias. The linked PR test must prove the selected
-representation works through Apptainer, CVMFS, modules, an old client, and a
-direct legacy pathname with no resolver involved.
+- [ ] maintainers approve the identity and legacy-path decisions in this
+  document;
+- [ ] the two required PRs link each other and pin the same schema and fixtures;
+- [ ] `neurodesk/neurocontainers#2913` and `neurodesk/neurocontainers#2914`
+  have one agreed integration outcome;
+- [ ] `neurodesk/neurocommand#767` has one agreed prerequisite, integration, or
+  supersession outcome;
+- [ ] all repository-local and exact-head tests pass;
+- [ ] the unchanged Neurodesktop test passes, or its conditional PR is ready;
+- [ ] OCI promotion and CVMFS publication failure injection passes;
+- [ ] generated views remain unchanged when CVMFS publication or its
+  acknowledgement fails;
+- [ ] previous generated metadata, OCI pointer digests, and CVMFS revision are
+  recorded;
+- [ ] destructive cleanup and legacy removal are absent from the diff; and
+- [ ] maintainers for the affected repositories confirm the window.
 
-### Merge window and go/no-go
-
-Merge in the table order during one scheduled window. Earlier PRs contain
-backwards-compatible consumers only; the Neurocontainers producer is the
-activation boundary and merges last. If the expected Neurodesktop change is
-unnecessary, record the test evidence on the tracker rather than opening an
-empty coordination PR.
-
-The merge proceeds only when:
-
-- the contract decisions below are approved;
-- all required PRs approve and pin the same contract;
-- all repository-local and exact-head cross-repository checks pass;
-- the OCI candidate graph and CVMFS transaction both pass preflight;
-- legacy clients resolve the same tested digest through the compatibility view;
-- previous OCI pointer digests and the previous CVMFS revision are recorded;
-- destructive cleanup and legacy removal are absent; and
-- maintainers for every affected repository confirm the merge order and window.
-
-Any failed condition stops the whole merge train. It does not create another
-deployment state to support.
+Failure of any item stops the merge train. It does not create another supported
+mode or justify bypassing compatibility.
 
 ## Rollback
 
-Rollback changes pointers and generated views; it does not rebuild, overwrite,
-or delete immutable content:
+Rollback changes selection and generated views; it does not rebuild or delete
+immutable content.
 
-- before activation, do not merge the producer PR and revert any already-merged
-  consumer PR only if necessary;
-- restore floating OCI pointers to their recorded previous digests;
-- remove or withdraw the activating canonical manifest from generated release
-  state so capability detection returns consumers to the legacy resolver;
-- restore the previous generated `apps.json` and module views;
-- abort an unpublished CVMFS transaction or restore the recorded previous
-  revision after publication; and
-- retain immutable legacy OCI tags, SIF objects, and CVMFS paths throughout.
+- Before a release manifest enters trusted release history, the pushed
+  candidate graph is inert.
+- If promotion fails, do not commit the release manifest or advance floating
+  tags.
+- If CVMFS publication fails after the history commit, leave generated views
+  and floating tags unchanged; the unselected immutable manifest may remain.
+- If activation fails after generated views change, restore the previous
+  `apps.json`, `cvmfs/log.txt`, module views, and floating-tag digests.
+- Abort an unpublished CVMFS transaction. If publication completed, restore the
+  recorded previous CVMFS revision.
+- A new client automatically returns to legacy resolution when the schema-v1
+  release is no longer selected.
+- Existing clients continue using unchanged legacy releases and the retained
+  legacy paths of new releases.
 
-Because consumers automatically fall back when no valid schema-v1 manifest is
-present, producer rollback does not require rebuilding a container or an
-emergency consumer release. Investigation can use the immutable candidate
-objects without exposing them as an active release.
+The immutable release manifest and candidate objects may remain for diagnosis;
+they are not selected and are not deleted during rollback.
 
-## Validation requirements
+## Expected code impact
 
-### Neurocontainers
+This is a review map, not permission to expand the change beyond the stated
+scope.
 
-- JSON Schema positive and negative tests.
-- Variant matrix tests for default, ARM, GPU, and combined flavour/platform
-  cases.
-- Tests that architecture aliases normalize to OCI values.
-- Candidate tamper tests for name, version, flavour, platform, build date,
-  index digest, child digest, and SIF digest.
-- Multi-platform promotion tests that refuse partial indexes.
-- Tests that a same-day conflicting immutable release is rejected.
-- Referrer attachment and mirrored-graph verification tests.
-- Fulltest selection from a platform entry without wildcard filenames.
-
-### Neurocommand
-
-- Manifest loading and forward-compatible schema tests.
-- Host-platform and explicit-flavour selection tests.
-- CVMFS path generation tests for every variant rule.
-- Legacy flat-name parsing tests from PR #767.
-- Native referrers, fallback-tag, missing-referrer, multiple-referrer,
-  wrong-subject, wrong-platform, and bad-digest tests.
-- Module generation without a hard-coded mount path.
-- Exact legacy-path generation and canonical-content equivalence tests.
-- Empty deploy command rejection.
-- Cleanup reachability tests proving hidden and non-active retained releases are
-  not deleted.
-- CVMFS reconciliation tests that use manifest identity rather than regex
-  replacement.
-
-### Neurodesktop
-
-- Startup with an externally mounted CVMFS repository.
-- Startup with an internal FUSE mount.
-- CVMFS-disabled OCI download.
-- AMD64 and ARM64 module selection.
-- Local container persistence across image upgrades.
-- Test-runner lookup through release ID rather than a constructed flat path.
-
-## GitHub context reviewed
-
-As of 2026-07-28, this review inventoried all open items in the two requested
-repositories:
-
-- Neurocommand: 4 open issues and 1 open PR.
-- Neurocontainers: 29 open issues and 2 open PRs.
-
-Directly relevant items:
-
-| Item | Relevance |
-|---|---|
-| [neurocommand#733](https://github.com/neurodesk/neurocommand/issues/733) | ARM publication, variants, parsing breakpoints, artifact cleanup, and maintainer direction. |
-| [neurocommand#152](https://github.com/neurodesk/neurocommand/issues/152) | Module portability, runtime selection, configurable CVMFS mount, and reviewable module generation. |
-| [neurocommand#75](https://github.com/neurodesk/neurocommand/issues/75) | Generated transparent-singularity paths become stale when local storage moves. |
-| [neurocommand#13](https://github.com/neurodesk/neurocommand/issues/13) | Broader packaging of Neurocommand; no direct layout requirement. |
-| [neurocommand#767](https://github.com/neurodesk/neurocommand/pull/767) | Draft end-to-end concrete variant support and the required legacy compatibility parser. |
-| [neurocontainers#1092](https://github.com/neurodesk/neurocontainers/issues/1092) | General CPU/GPU/architecture variation model. |
-| [neurocontainers#1252](https://github.com/neurodesk/neurocontainers/issues/1252) | ARM build infrastructure. |
-| [neurocontainers#2593](https://github.com/neurodesk/neurocontainers/issues/2593) | Same-tag multi-architecture/referrer direction and CVMFS current-snapshot policy. |
-| [neurocontainers#2408](https://github.com/neurodesk/neurocontainers/issues/2408) | v2 OCI repository, immutable tag, SIF referrer, and floating-tag model. |
-| [neurocontainers#2409](https://github.com/neurodesk/neurocontainers/issues/2409) | OCI labels and SIF annotations. |
-| [neurocontainers#2796](https://github.com/neurodesk/neurocontainers/issues/2796) | Fulltest artifact selection from release metadata. |
-| [neurocontainers#1906](https://github.com/neurodesk/neurocontainers/issues/1906) | CVMFS client configuration distribution; mount configuration remains outside this layout proposal. |
-| [neurocontainers#1253](https://github.com/neurodesk/neurocontainers/issues/1253) | CVMFS metrics; useful for measuring compatibility and fallback usage. |
-| [neurocontainers#61](https://github.com/neurodesk/neurocontainers/issues/61) | CVMFS scanning; the manifest enables structured reconciliation. |
-| [neurocontainers#218](https://github.com/neurodesk/neurocontainers/issues/218) | Container metadata/database direction. |
-| [neurocontainers#504](https://github.com/neurodesk/neurocontainers/issues/504) | Signing and supply-chain metadata fit the OCI subject graph. |
-| [neurocontainers#2950](https://github.com/neurodesk/neurocontainers/issues/2950) | Registry-native manifest/config access supports the general move away from pulling content to inspect metadata. |
-| [neurocontainers#2913](https://github.com/neurodesk/neurocontainers/pull/2913) | Draft first-class variant builder and release fan-out. |
-| [neurocontainers#2914](https://github.com/neurodesk/neurocontainers/pull/2914) | Draft tested-candidate promotion and manifest foundation. |
-
-The remaining open Neurocontainers issues are application requests or isolated
-build/release failures and do not change the proposed layout.
-
-## Standards and operational references
-
-- [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/main/image-index.md)
-- [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md)
-- [OCI Distribution Specification: referrers and fallback tag schema](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
-- [ORAS attached artifacts](https://oras.land/docs/concepts/reftypes/)
-- [ORAS `attach` command](https://oras.land/docs/commands/oras_attach/)
-- [Apptainer OCI registry documentation](https://apptainer.org/docs/user/latest/registry.html)
-- [CVMFS nested catalog recommendations](https://cvmfs.readthedocs.io/en/2.14/cpt-repo/#managing-nested-catalogs)
-- [CVMFS content hashes and hard-link constraints](https://cvmfs.readthedocs.io/en/2.14/cpt-details/#file-catalog)
-- [CVMFS repository integrity checks](https://cvmfs.readthedocs.io/en/stable/cpt-repo.html)
+| Repository | Area | Required change |
+|---|---|---|
+| Neurocontainers | `builder/variants.py` and callers in `neurodesk/neurocontainers#2913` | Preserve logical name, build variant, platform, and legacy concrete identity as separate fields. |
+| Neurocontainers | candidate/promotion code in `neurodesk/neurocontainers#2914` | Matrix over all required candidates and bind every artifact to the tested PR head. |
+| Neurocontainers | release generation | Validate schema, retain build history, record post-push digests, and generate the OCI graph. |
+| Neurocommand | `fetch_and_run.sh`, `fetch_containers.sh`, transparent-singularity | Call one manifest resolver for schema-v1 releases and retain legacy fallback. |
+| Neurocommand | `sync_containers_to_cvmfs.sh` | Consume release manifests and publish canonical plus legacy paths atomically. |
+| Neurocommand | `reconcile_module_files.py` | Use explicit manifest identity for new releases and retain the legacy parser. |
+| Neurocommand | `write_log.py`, `build_menu.py`, `containers.sh` | Generate compatibility views without parsing presentation labels. |
+| Neurocommand | upload/cleanup and DOI workflows | Use manifest inventory and keep both identities; perform no activation-time deletion. |
+| Neurodesktop | `environment_variables.sh`, `test_neurodesktop.sh` | Expected to remain unchanged; use them as compatibility tests. |
 
 ## Alternatives considered
 
 ### Keep the flat layout and parse from the right
 
-This is the lowest-risk compatibility step and PR #767 should retain it for old
-identities. It does not remove coupling between storage paths, module names,
-display names, cleanup keys, and registry names, so it is not the target.
+This is required for old releases and is correctly improved by
+`neurodesk/neurocommand#767`. It does not provide a durable release schema,
+multi-platform OCI selection, or a safe inventory, so it remains a
+compatibility adapter.
 
-### Encode every flavour and architecture into the container name
+### Publish every concrete variant as a separate logical name
 
-This matches the first implementation in PR #2913 and is easy for legacy
-Neurocommand consumers. It creates separate OCI repositories and user-facing
-module names for what are otherwise dimensions of one logical tool, and it does
-not implement the same-tag multi-architecture direction in issue #2593.
+This is the current direction in `neurodesk/neurocommand#733` and the first
+implementation in `neurodesk/neurocontainers#2913`. It is simple for legacy
+consumers, but makes ARM a different tool, creates separate OCI repositories,
+and conflicts with the same-tag multi-architecture direction accepted in
+[neurocontainers#2593](https://github.com/neurodesk/neurocontainers/issues/2593).
+This proposal retains those concrete names only as explicit compatibility
+identities.
 
-This proposal preserves distinct concrete variants but stores their axes in the
-manifest and CVMFS release name. Maintainers should explicitly confirm this
-change from the current draft PR direction.
+### Put architecture in separate OCI tags
 
-### Publish a separate OCI tag for every architecture
+That moves platform selection into custom tag naming and duplicates logic that
+OCI image indexes already standardize. Architecture-specific candidate tags may
+exist during a build, but they are not public release identities.
 
-This works with simple clients but moves host selection into tag naming,
-duplicates floating-tag policy, and conflicts with the agreed image-index
-direction. Architecture-specific tags may exist as temporary build inputs, but
-they are not public release identities.
+### Attach every SIF to the top-level index
 
-### Attach all SIFs only to the top-level index
+A SIF is platform-specific. Attaching it to the exact child image manifest
+gives it an unambiguous OCI platform subject and lets the release manifest
+record one exact SIF per platform.
 
-Custom annotations could distinguish them, but standard platform resolution
-would not identify one SIF subject. Attaching to each child manifest gives the
-SIF the same platform identity as the runnable image.
+### Rename the unpacked payload to `rootfs`
 
-### Continue treating `apps.json` as the canonical inventory
+That name is clearer than a directory ending in `.simg`, but it would require
+another compatibility alias inside every release and changes more publisher,
+module, maintenance, and test code. Keeping the existing inner name is safer
+for this change.
 
-`apps.json` is a presentation/publication view. It cannot safely represent
-candidate, hidden, archived, withdrawn, and multi-platform artifacts without
-becoming another release database. Its past use as a cleanup keep-list already
-deleted valid hidden ARM artifacts.
+### Change Neurodesktop at the same time
 
-## Questions requiring maintainer decision
+Changing code merely because it constructs an old path would weaken the proof
+that old paths remain compatible. The current Neurodesktop test should pass
+unchanged. A third PR is justified only by a demonstrated failure.
 
-| Question | Recommendation |
-|---|---|
-| Should product flavour and platform remain separate internally? | Yes. Derive the single CVMFS `variant` token from both. |
-| Should ARM remain a distinct name such as `fsl_arm64`? | No for the target OCI/CVMFS model; retain it only as a legacy alias. |
-| How should product flavours appear in OCI? | Separate immutable tags/indexes within the same logical repository. |
-| What is the SIF subject? | The exact platform child manifest. |
-| What is the canonical architecture vocabulary? | OCI `amd64` and `arm64`; accept recipe aliases at input. |
-| What is the unpacked CVMFS payload called? | `rootfs`, with a required legacy inner-name view for every published compatibility alias. |
-| What is the release-history path in Neurocontainers? | `releases/<name>/<version>/<flavour>/<build_date>.json`. |
-| Which registry is primary? | Ratify Quay-primary versus GHCR-critical; record and verify each registry independently meanwhile. |
-| What happens on a conflicting same-day rebuild? | Fail promotion; approve an extended build ID before allowing it. |
-| How does `module load name/version` select architecture? | Use the shared resolver/platform dispatcher; never fix the module to AMD64. |
-| How long are flat CVMFS aliases retained? | This change sets no removal date. Removal requires a separate proposal based on observed usage and supported-client policy. |
-| Is the legacy `.simg` object-store path retained? | Yes. Its removal is outside this change and requires measured usage plus a separate proposal. |
+## Consequences
 
-Approval of those decisions is sufficient to open the linked implementation
-PRs and merge them as one coordinated train across the affected repositories.
+The proposal intentionally accepts:
+
+- two CVMFS namespace entries for every new payload;
+- a permanent legacy resolver for historical releases;
+- a schema and generated compatibility views that must be versioned and tested
+  across repositories;
+- an OCI index even for single-platform releases;
+- rejection rather than overwrite for same-day conflicting builds; and
+- a larger coordinated implementation review in exchange for avoiding
+  long-lived mixed contracts.
+
+It avoids:
+
+- moving existing containers;
+- duplicating unpacked payload data in the normal compatibility representation;
+- encoding platform into a logical tool name;
+- choosing artifacts by list order or floating tags;
+- using menu visibility as retention truth; and
+- requiring a Neurodesktop source change without evidence.
+
+## Maintainer ratification
+
+Approval of this document means agreement that:
+
+- [ ] release identity excludes platform, while platform artifact identity adds
+  it;
+- [ ] build variant and platform remain separate manifest fields;
+- [ ] the CVMFS variant is their explicit stored projection;
+- [ ] logical names remain stable in the target OCI/CVMFS model, superseding
+  concrete platform names as the target from
+  `neurodesk/neurocommand#733`;
+- [ ] SIFs attach to platform child manifests;
+- [ ] every new canonical CVMFS release includes its full manifest-declared
+  legacy path in the same transaction;
+- [ ] the existing inner `.simg` layout, legacy module aliases, and public
+  module roots remain;
+- [ ] existing releases are not backfilled or removed;
+- [ ] the immutable release manifest contains no mutable lifecycle status, and
+  generated views activate it only after CVMFS acknowledges both paths; and
+- [ ] implementation uses two required linked PRs, with Neurodesktop conditional
+  on a failing compatibility test.
+
+Once these boxes are agreed, the linked implementation PRs can be opened and
+reviewed as one contract without further design stages.
+
+## Relevant discussions and specifications
+
+- [neurocommand#733: ARM and variant publication](https://github.com/neurodesk/neurocommand/issues/733)
+- [neurocommand#767: legacy named-variant compatibility](https://github.com/neurodesk/neurocommand/pull/767)
+- [neurocontainers#1092: general container variations](https://github.com/neurodesk/neurocontainers/issues/1092)
+- [neurocontainers#2408: v2 OCI repository and tag layout](https://github.com/neurodesk/neurocontainers/issues/2408)
+- [neurocontainers#2593: same-tag multi-architecture direction](https://github.com/neurodesk/neurocontainers/issues/2593)
+- [neurocontainers#2796: fulltest selection from release metadata](https://github.com/neurodesk/neurocontainers/issues/2796)
+- [neurocontainers#2913: first-class variant fan-out](https://github.com/neurodesk/neurocontainers/pull/2913)
+- [neurocontainers#2914: tested candidate promotion](https://github.com/neurodesk/neurocontainers/pull/2914)
+- [OCI image index specification](https://github.com/opencontainers/image-spec/blob/main/image-index.md)
+- [OCI image manifest specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md)
+- [OCI Distribution 1.1 referrers and fallback tag schema](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+- [Apptainer OCI registry documentation](https://apptainer.org/docs/user/latest/registry.html)
+- [CVMFS nested catalogs](https://cvmfs.readthedocs.io/en/2.14/cpt-repo/#managing-nested-catalogs)
+- [CVMFS content hashes and hard-link constraints](https://cvmfs.readthedocs.io/en/2.14/cpt-details/#file-catalog)


### PR DESCRIPTION
## Summary

This documentation PR proposes one manifest-backed distribution contract for Neurocontainers, OCI, CVMFS, Neurocommand, and Neurodesktop:

- canonical CVMFS releases at `/containers/<name>/<software-version>_<cvmfs-variant>_<build-date>/`
- one logical multi-platform release with separate platform artifacts
- one OCI image index per immutable release tag, with each SIF attached to its platform child manifest
- an immutable release manifest containing exact OCI digests, canonical CVMFS paths, source provenance, and deploy metadata
- two required linked implementation PRs—Neurocommand and Neurocontainers—with Neurodesktop conditional on a demonstrated compatibility failure

The canonical release manifest deliberately contains no legacy names, aliases, or object keys.

## Backwards compatibility without a second identity system

Existing releases remain untouched. For new schema-v1 releases, a separately versioned Neurocommand adapter preserves only the existing default-AMD64 flat-path contract:

```text
/containers/fsl_6.0.7.16_20260728
  -> fsl/6.0.7.16_amd64_20260728
```

The outer alias is a directory symlink because POSIX/CVMFS cannot hard-link directories. It preserves the complete old default path while keeping one unpacked payload. The canonical inner payload name is uniform across platforms and does not carry concrete candidate names.

ARM and named variants are canonical-only by default. The publisher must not manufacture `fsl_arm64_*`, `fsl_gpu_*`, or similar aliases from manifest axes. The Neurocommand policy has one bounded rule for `default + linux/amd64`; extending it requires evidence, maintainer approval, and a regression fixture. Legacy parsing and policy projection live in one adapter and are forbidden from spreading into the canonical resolver, schema, modules, inventory, or cleanup authority.

Legacy-format views contain only releases they can safely represent. A manifest-aware ARM client must never select the AMD64 flat alias; if a supported ARM Neurodesktop path still constructs it, the conditional Neurodesktop PR becomes required before ARM publication.

## Availability gate

A release is exposed only after one ordered promotion completes:

1. verify every required variant/platform candidate at its exact PR head;
2. publish and verify the complete OCI index, child manifests, SIF referrers, and clean immutable release manifest;
3. publish canonical CVMFS paths and any Neurocommand-policy alias in one transaction; and
4. after CVMFS acknowledgement, update generated views and floating tags.

A schema-v1 selection with a missing, malformed, or unsupported manifest fails closed; it cannot downgrade into legacy underscore parsing. Cleanup starts from canonical manifest inventory, not `apps.json`, `cvmfs/log.txt`, or alias paths. No destructive cleanup occurs in activation or rollback.

## Linked implementation contract

The implementation merge train is:

1. required Neurocommand consumer/publisher PR;
2. conditional Neurodesktop PR only if exact-head testing proves one is needed; and
3. required integrated Neurocontainers producer PR, merged last.

The Neurocommand PR must state whether [neurocommand#767](https://github.com/neurodesk/neurocommand/pull/767) is its base, integrated into the compatibility adapter, or superseded. The Neurocontainers PR must give one integration outcome for [neurocontainers#2913](https://github.com/neurodesk/neurocontainers/pull/2913) and [neurocontainers#2914](https://github.com/neurodesk/neurocontainers/pull/2914). All required PRs remain draft until one reproducible run records their exact commit SHAs and passes the cross-repository matrix.

## Important design decision

This proposal deliberately changes the target distribution model recorded in [neurocommand#733](https://github.com/neurodesk/neurocommand/issues/733). Concrete names such as `fsl_gpu_arm64` may remain internal build-candidate names, but logical name, build variant, and OCI platform become separate manifest fields. They do not become public compatibility identities. This aligns the layout with the same-tag multi-architecture direction in [neurocontainers#2593](https://github.com/neurodesk/neurocontainers/issues/2593).

## Impact

Documentation only. This PR changes no runtime, workflow, registry, CVMFS, metadata, or cleanup behaviour.

## Validation

- reread the proposal end to end after isolating backwards compatibility
- traced current publisher, resolver, module, cleanup, object-store, menu, and Neurodesktop test behaviour
- rechecked the active patches in neurocommand#767 and neurocontainers#2913/#2914
- validated the illustrative release JSON with `jq`
- checked that the manifest example contains no legacy identity fields
- audited all 230 current Neurocontainers recipe versions against the proposed OCI tag vocabulary
- verified code-fence balance, repository-relative links, Markdown table shapes, and Git whitespace
- checked the design against the OCI Distribution/Image specifications and CVMFS hard-link, content-hash, transaction, and nested-catalog behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive proposal for versioned Neurocontainers releases across OCI registries, CVMFS, Neurocommand, and Neurodesktop.
  * Documented canonical release identities, platform and variant handling, immutable release manifests, validation rules, and promotion checks.
  * Defined compatibility behavior for existing AMD64 paths, manifest-aware resolution, rollback procedures, and coordinated release workflows.
  * Clarified how generated views, launchers, and keep-lists are published only after successful CVMFS verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->